### PR TITLE
New API utilizing dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ labels = convert(Array, iris[:, 5]);
 Pruned Tree Classifier
 ```julia
 # train full-tree classifier
-model = build_tree(labels, features)
+model = tree(labels, features)
 # prune tree: merge leaves having >= 90% combined purity (default: 100%)
-model = prune_tree(model, 0.9)
+model = prune(model, 0.9)
 # pretty print of the tree, to a depth of 5 nodes (optional)
 print_tree(model, 5)
 # apply learned model
-apply_tree(model, [5.9,3.0,5.1,1.9])
+apply(model, [5.9,3.0,5.1,1.9])
 # get the probability of each label
-apply_tree_proba(model, [5.9,3.0,5.1,1.9], ["setosa", "versicolor", "virginica"])
+apply_proba(model, [5.9,3.0,5.1,1.9], ["setosa", "versicolor", "virginica"])
 # run n-fold cross validation for pruned tree,
 # using 90% purity threshold pruning, and 3 CV folds
 accuracy = nfoldCV_tree(labels, features, 0.9, 3)
@@ -69,11 +69,11 @@ Random Forest Classifier
 ```julia
 # train random forest classifier
 # using 2 random features, 10 trees, 0.5 portion of samples per tree (optional), and a maximum tree depth of 6 (optional)
-model = build_forest(labels, features, 2, 10, 0.5, 6)
+model = forest(labels, features, 2, 10, 0.5, 6)
 # apply learned model
-apply_forest(model, [5.9,3.0,5.1,1.9])
+apply(model, [5.9,3.0,5.1,1.9])
 # get the probability of each label
-apply_forest_proba(model, [5.9,3.0,5.1,1.9], ["setosa", "versicolor", "virginica"])
+apply_proba(model, [5.9,3.0,5.1,1.9], ["setosa", "versicolor", "virginica"])
 # run n-fold cross validation for forests
 # using 2 random features, 10 trees, 3 folds, and 0.5 portion of samples per tree (optional)
 accuracy = nfoldCV_forest(labels, features, 2, 10, 3, 0.5)
@@ -81,11 +81,11 @@ accuracy = nfoldCV_forest(labels, features, 2, 10, 3, 0.5)
 Adaptive-Boosted Decision Stumps Classifier
 ```julia
 # train adaptive-boosted stumps, using 7 iterations
-model, coeffs = build_adaboost_stumps(labels, features, 7);
+model, coeffs = adaboost_stumps(labels, features, 7);
 # apply learned model
-apply_adaboost_stumps(model, coeffs, [5.9,3.0,5.1,1.9])
+apply(model, coeffs, [5.9,3.0,5.1,1.9])
 # get the probability of each label
-apply_adaboost_stumps_proba(model, coeffs, [5.9,3.0,5.1,1.9], ["setosa", "versicolor", "virginica"])
+apply_proba(model, coeffs, [5.9,3.0,5.1,1.9], ["setosa", "versicolor", "virginica"])
 # run n-fold cross validation for boosted stumps, using 7 iterations and 3 folds
 accuracy = nfoldCV_stumps(labels, features, 7, 3)
 ```
@@ -100,9 +100,9 @@ labels = features * weights;
 Regression Tree
 ```julia
 # train regression tree, using an averaging of 5 samples per leaf (optional)
-model = build_tree(labels, features, 5)
+model = tree(labels, features, 5)
 # apply learned model
-apply_tree(model, [-0.9,3.0,5.1,1.9,0.0])
+apply(model, [-0.9,3.0,5.1,1.9,0.0])
 # run n-fold cross validation, using 3 folds and averaging of 5 samples per leaf (optional)
 # returns array of coefficients of determination (R^2)
 r2 = nfoldCV_tree(labels, features, 3, 5)
@@ -111,9 +111,9 @@ Regression Random Forest
 ```julia
 # train regression forest, using 2 random features, 10 trees,
 # averaging of 5 samples per leaf (optional), and 0.7 portion of samples per tree (optional)
-model = build_forest(labels, features, 2, 10, 5, 0.7)
+model = forest(labels, features, 2, 10, 5, 0.7)
 # apply learned model
-apply_forest(model, [-0.9,3.0,5.1,1.9,0.0])
+apply(model, [-0.9,3.0,5.1,1.9,0.0])
 # run n-fold cross validation on regression forest
 # using 2 random features, 10 trees, 3 folds, averaging of 5 samples per leaf (optional),
 # and 0.7 porition of samples per tree (optional)
@@ -134,7 +134,7 @@ fit!(model, features, labels)
 # pretty print of the tree, to a depth of 5 nodes (optional)
 print_tree(model.root, 5)
 # apply learned model
-predict(model, [5.9,3.0,5.1,1.9])
+apply_proba(model, [5.9,3.0,5.1,1.9])
 # get the probability of each label
 predict_proba(model, [5.9,3.0,5.1,1.9])
 println(get_classes(model)) # returns the ordering of the columns in predict_proba's output

--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -6,10 +6,9 @@ using Compat
 
 import Base: length, convert, promote_rule, show, start, next, done
 
-export Leaf, Node, Ensemble, print_tree, depth, build_stump, build_tree,
-       prune_tree, apply_tree, apply_tree_proba, nfoldCV_tree, build_forest,
-       apply_forest, apply_forest_proba, nfoldCV_forest, build_adaboost_stumps,
-       apply_adaboost_stumps, apply_adaboost_stumps_proba, nfoldCV_stumps,
+export Leaf, Node, Ensemble, print_tree, depth, stump, tree,
+       prune, apply, apply_proba, nfoldCV_tree, forest,
+       predict, nfoldCV_forest, adaboost_stumps, nfoldCV_stumps,
        majority_vote, ConfusionMatrix, confusion_matrix, mean_squared_error,
        R2, _int
 
@@ -52,6 +51,10 @@ end
 
 @compat const LeafOrNode = Union{Leaf,Node}
 
+immutable Forest
+    trees::Vector{Node}
+end
+
 immutable Ensemble
     trees::Vector{Node}
 end
@@ -84,6 +87,7 @@ include("scikitlearnAPI.jl")
 
 length(leaf::Leaf) = 1
 length(tree::Node) = length(tree.left) + length(tree.right)
+length(forest::Forest) = length(forest.trees)
 length(ensemble::Ensemble) = length(ensemble.trees)
 
 depth(leaf::Leaf) = 0

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -142,17 +142,17 @@ function _nfoldCV(classifier::Symbol, labels, features, args...)
         train_features = features[inds[train_inds],:]
         train_labels = labels[inds[train_inds]]
         if classifier == :tree
-            model = build_tree(train_labels, train_features, 0)
+            model = tree(train_labels, train_features, 0)
             if pruning_purity < 1.0
-                model = prune_tree(model, pruning_purity)
+                model = prune(model, pruning_purity)
             end
-            predictions = apply_tree(model, test_features)
+            predictions = apply(model, test_features)
         elseif classifier == :forest
-            model = build_forest(train_labels, train_features, nsubfeatures, ntrees, partialsampling)
-            predictions = apply_forest(model, test_features)
+            model = forest(train_labels, train_features, nsubfeatures, ntrees, partialsampling)
+            predictions = apply(model, test_features)
         elseif classifier == :stumps
-            model, coeffs = build_adaboost_stumps(train_labels, train_features, niterations)
-            predictions = apply_adaboost_stumps(model, coeffs, test_features)
+            model, coeffs = adaboost_stumps(train_labels, train_features, niterations)
+            predictions = apply(model, coeffs, test_features)
         end
         cm = confusion_matrix(test_labels, predictions)
         accuracy[i] = cm.accuracy
@@ -207,11 +207,11 @@ function _nfoldCV{T<:Float64, U<:Real}(regressor::Symbol, labels::Vector{T}, fea
         train_features = features[inds[train_inds],:]
         train_labels = labels[inds[train_inds]]
         if regressor == :tree
-            model = build_tree(train_labels, train_features, maxlabels, 0)
-            predictions = apply_tree(model, test_features)
+            model = tree(train_labels, train_features, maxlabels, 0)
+            predictions = apply(model, test_features)
         elseif regressor == :forest
-            model = build_forest(train_labels, train_features, nsubfeatures, ntrees, maxlabels, partialsampling)
-            predictions = apply_forest(model, test_features)
+            model = forest(train_labels, train_features, nsubfeatures, ntrees, maxlabels, partialsampling)
+            predictions = apply(model, test_features)
         end
         err = mean_squared_error(test_labels, predictions)
         corr = cor(test_labels, predictions)

--- a/test/classification_hetero.jl
+++ b/test/classification_hetero.jl
@@ -15,18 +15,18 @@ features[:,2] = string.(tf[randperm(m)]);
 features[:,3] = round(Int, features[:,3]);
 features[:,4] = tf[inds];
 
-model = build_tree(labels, features);
-preds = apply_tree(model, features);
-cm = confusion_matrix(labels, preds);
+model = tree(labels, features)
+preds = apply(model, features)
+cm = confusion_matrix(labels, preds)
 @test cm.accuracy > 0.7
 
-model = build_forest(labels, features,2,3);
-preds = apply_forest(model, features);
-cm = confusion_matrix(labels, preds);
+model = forest(labels, features,2,3)
+preds = apply(model, features)
+cm = confusion_matrix(labels, preds)
 @test cm.accuracy > 0.7
 
-model, coeffs = build_adaboost_stumps(labels, features, 7);
-preds = apply_adaboost_stumps(model, coeffs, features);
-cm = confusion_matrix(labels, preds);
+model, coeffs = adaboost_stumps(labels, features, 7)
+preds = apply(model, coeffs, features)
+cm = confusion_matrix(labels, preds)
 @test cm.accuracy > 0.7
 

--- a/test/classification_rand.jl
+++ b/test/classification_rand.jl
@@ -9,7 +9,7 @@ weights = rand(-1:1,m);
 labels = _int(features * weights);
 
 maxdepth = 3
-model = build_tree(labels, features, 0, maxdepth)
+model = tree(labels, features, 0, maxdepth)
 @test depth(model) == maxdepth
 
 println("\n##### nfoldCV Classification Tree #####")

--- a/test/iris.jl
+++ b/test/iris.jl
@@ -7,31 +7,31 @@ features = convert(Array, iris[:, 1:4]);
 labels = convert(Array, iris[:, 5]);
 
 # train full-tree classifier
-model = build_tree(labels, features)
+model = tree(labels, features)
 # prune tree: merge leaves having >= 90% combined purity (default: 100%)
-model = prune_tree(model, 0.9)
+model = prune(model, 0.9)
 # pretty print of the tree, to a depth of 5 nodes (optional)
 print_tree(model, 5)
 # apply learned model
-apply_tree(model, [5.9,3.0,5.1,1.9])
+apply(model, [5.9,3.0,5.1,1.9])
 # run n-fold cross validation for pruned tree, using 90% purity threshold purning, and 3 CV folds
 println("\n##### nfoldCV Classification Tree #####")
 accuracy = nfoldCV_tree(labels, features, 0.9, 3)
 @test mean(accuracy) > 0.8
 
 # train random forest classifier, using 2 random features, 10 trees and 0.5 of samples per tree (optional, defaults to 0.7)
-model = build_forest(labels, features, 2, 10, 0.5)
+model = forest(labels, features, 2, 10, 0.5)
 # apply learned model
-apply_forest(model, [5.9,3.0,5.1,1.9])
+apply(model, [5.9,3.0,5.1,1.9])
 # run n-fold cross validation for forests, using 2 random features, 10 trees, 3 folds, 0.5 of samples per tree (optional, defaults to 0.7)
 println("\n##### nfoldCV Classification Forest #####")
 accuracy = nfoldCV_forest(labels, features, 2, 10, 3, 0.5)
 @test mean(accuracy) > 0.8
 
 # train adaptive-boosted decision stumps, using 7 iterations
-model, coeffs = build_adaboost_stumps(labels, features, 7);
+model, coeffs = adaboost_stumps(labels, features, 7);
 # apply learned model
-apply_adaboost_stumps(model, coeffs, [5.9,3.0,5.1,1.9])
+apply(model, coeffs, [5.9,3.0,5.1,1.9])
 # run n-fold cross validation for boosted stumps, using 7 iterations and 3 folds
 println("\n##### nfoldCV Classification Adaboosted Stumps #####")
 nfoldCV_stumps(labels, features, 7, 3)

--- a/test/regression_rand.jl
+++ b/test/regression_rand.jl
@@ -7,7 +7,7 @@ weights = rand(-2:2,m);
 labels = features * weights;
 
 maxdepth = 3
-model = build_tree(labels, features, 5, 0, maxdepth)
+model = tree(labels, features, 5, 0, maxdepth)
 @test depth(model) == maxdepth
 
 println("\n##### nfoldCV Regression Tree #####")


### PR DESCRIPTION
I don't know if you want this but after having used this package a bit I thought it would make more sense to make use of dispatch instead of including `tree` and `forest` in the function names. I also think the `build` part of the model constructors is redundant so that has also been removed. I'd actually also prefer to use predict instead of `apply_proba` and maybe `predictclass` instead of `apply` but this clashes a bit with SciKitLearn which (again) has decided to deviate from how predicted values are defined in e.g. R's `rpart`.

No problem if you don't want this change. If you think it makes sense, I'll add deprecations for the old methods to this PR.