### PR TITLE
Add support for DataFrames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.org/bensadeghi/DecisionTree.jl.svg?branch=master)](https://travis-ci.org/bensadeghi/DecisionTree.jl)
 [![Coverage Status](https://coveralls.io/repos/bensadeghi/DecisionTree.jl/badge.svg?branch=master)](https://coveralls.io/r/bensadeghi/DecisionTree.jl?branch=master)
 
-[![DecisionTree](http://pkg.julialang.org/badges/DecisionTree_0.5.svg)](http://pkg.julialang.org/?pkg=DecisionTree&ver=0.5)
 [![DecisionTree](http://pkg.julialang.org/badges/DecisionTree_0.6.svg)](http://pkg.julialang.org/?pkg=DecisionTree&ver=0.6)
 
 Decision Tree Classifier and Regressor in Julia

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
-julia 0.5
+julia 0.6
 ScikitLearnBase 0.0.4
+DataFrames 0.11

--- a/src/dataframesAPI.jl
+++ b/src/dataframesAPI.jl
@@ -1,0 +1,23 @@
+# helper function to check DataFrame input
+function _check_dataframe_input(data::DataFrame, target_column::Union{Symbol, AbstractString})
+    target = isa(target_column, Symbol) ? target_column : Symbol(target_column)
+    colnames = names(data)
+    if target in colnames
+        features = setdiff(colnames, [target])
+        return data[target], data[features]
+    else
+        error("Specified `target_column` $(target_column) not present in data.")
+    end
+end
+
+function build_tree(data::DataFrame, target_column::Union{Symbol, AbstractString}, args...; rng=Base.GLOBAL_RNG)
+    build_tree(_check_dataframe_input(data, target_column)..., args..., rng=rng)
+end
+
+function build_forest(data::DataFrame, target_column::Union{Symbol, AbstractString}, args...; rng=Base.GLOBAL_RNG)
+    build_forest(_check_dataframe_input(data, target_column)..., args...; rng=rng)
+end
+
+function build_adaboost_stumps(data::DataFrame, target_column::Union{Symbol, AbstractString}, args...; rng=Base.GLOBAL_RNG)
+    build_adaboost_stumps(_check_dataframe_input(data, target_column)..., args...; rng=rng)
+end

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -1,4 +1,4 @@
-type ConfusionMatrix
+struct ConfusionMatrix
     classes::Vector
     matrix::Matrix{Int}
     accuracy::Float64
@@ -16,7 +16,7 @@ function show(io::IO, cm::ConfusionMatrix)
     show(io, cm.kappa)
 end
 
-function _hist_add!{T}(counts::Dict{T,Int}, labels::Vector{T}, region::UnitRange{Int})
+function _hist_add!{T}(counts::Dict{T,Int}, labels::AbstractVector{T}, region::UnitRange{Int})
     for i in region
         lbl = labels[i]
         counts[lbl] = get(counts, lbl, 0) + 1
@@ -24,7 +24,7 @@ function _hist_add!{T}(counts::Dict{T,Int}, labels::Vector{T}, region::UnitRange
     return counts
 end
 
-function _hist_sub!{T}(counts::Dict{T,Int}, labels::Vector{T}, region::UnitRange{Int})
+function _hist_sub!{T}(counts::Dict{T,Int}, labels::AbstractVector{T}, region::UnitRange{Int})
     for i in region
         lbl = labels[i]
         counts[lbl] -= 1
@@ -32,7 +32,7 @@ function _hist_sub!{T}(counts::Dict{T,Int}, labels::Vector{T}, region::UnitRange
     return counts
 end
 
-function _hist_shift!{T}(counts_from::Dict{T,Int}, counts_to::Dict{T,Int}, labels::Vector{T}, region::UnitRange{Int})
+function _hist_shift!{T}(counts_from::Dict{T,Int}, counts_to::Dict{T,Int}, labels::AbstractVector{T}, region::UnitRange{Int})
     for i in region
         lbl = labels[i]
         counts_from[lbl] -= 1
@@ -41,7 +41,7 @@ function _hist_shift!{T}(counts_from::Dict{T,Int}, counts_to::Dict{T,Int}, label
     return nothing
 end
 
-_hist{T}(labels::Vector{T}, region::UnitRange{Int} = 1:endof(labels)) = 
+_hist{T}(labels::AbstractVector{T}, region::UnitRange{Int} = 1:endof(labels)) = 
     _hist_add!(Dict{T,Int}(), labels, region)
 
 function _set_entropy{T}(counts::Dict{T,Int}, N::Int)
@@ -56,7 +56,7 @@ function _set_entropy{T}(counts::Dict{T,Int}, N::Int)
     return entropy
 end
 
-_set_entropy(labels::Vector) = _set_entropy(_hist(labels), length(labels))
+_set_entropy(labels::AbstractVector) = _set_entropy(_hist(labels), length(labels))
 
 function _info_gain{T}(N1::Int, counts1::Dict{T,Int}, N2::Int, counts2::Dict{T,Int})
     N = N1 + N2
@@ -64,19 +64,19 @@ function _info_gain{T}(N1::Int, counts1::Dict{T,Int}, N2::Int, counts2::Dict{T,I
     return H
 end
 
-function _neg_z1_loss{T<:Real}(labels::Vector, weights::Vector{T})
+function _neg_z1_loss{T<:Real}(labels::AbstractVector, weights::AbstractVector{T})
     missmatches = labels .!= majority_vote(labels)
     loss = sum(weights[missmatches])
     return -loss
 end
 
-function _weighted_error{T<:Real}(actual::Vector, predicted::Vector, weights::Vector{T})
+function _weighted_error{T<:Real}(actual::AbstractVector, predicted::AbstractVector, weights::AbstractVector{T})
     mismatches = actual .!= predicted
     err = sum(weights[mismatches]) / sum(weights)
     return err
 end
 
-function majority_vote(labels::Vector)
+function majority_vote(labels::AbstractVector)
     if length(labels) == 0
         return nothing
     end
@@ -94,7 +94,7 @@ end
 
 ### Classification ###
 
-function confusion_matrix(actual::Vector, predicted::Vector)
+function confusion_matrix(actual::AbstractVector, predicted::AbstractVector)
     @assert length(actual) == length(predicted)
     N = length(actual)
     _actual = zeros(Int,N)
@@ -115,7 +115,7 @@ function confusion_matrix(actual::Vector, predicted::Vector)
     return ConfusionMatrix(classes, CM, accuracy, kappa)
 end
 
-function _nfoldCV(classifier::Symbol, labels, features, args...)
+function _nfoldCV(classifier::Symbol, labels::AbstractArray, features::Union{Matrix, DataFrame}, args...)
     nfolds = args[end]
     if nfolds < 2
         return nothing
@@ -163,9 +163,12 @@ function _nfoldCV(classifier::Symbol, labels, features, args...)
     return accuracy
 end
 
-nfoldCV_tree(labels::Vector, features::Matrix, pruning_purity::Real, nfolds::Integer)                                           = _nfoldCV(:tree, labels, features, pruning_purity, nfolds)
-nfoldCV_forest(labels::Vector, features::Matrix, nsubfeatures::Integer, ntrees::Integer, nfolds::Integer, partialsampling=0.7)  = _nfoldCV(:forest, labels, features, nsubfeatures, ntrees, partialsampling, nfolds)
-nfoldCV_stumps(labels::Vector, features::Matrix, niterations::Integer, nfolds::Integer)                                         = _nfoldCV(:stumps, labels, features, niterations, nfolds)
+nfoldCV_tree(labels::AbstractVector, features::Union{Matrix, DataFrame}, pruning_purity::Real, nfolds::Integer)                                             = _nfoldCV(:tree, labels, features, pruning_purity, nfolds)
+nfoldCV_forest(labels::AbstractVector, features::Union{Matrix, DataFrame}, nsubfeatures::Integer, ntrees::Integer, nfolds::Integer, partialsampling=0.7)    = _nfoldCV(:forest, labels, features, nsubfeatures, ntrees, partialsampling, nfolds)
+nfoldCV_stumps(labels::AbstractVector, features::Union{Matrix, DataFrame}, niterations::Integer, nfolds::Integer)                                           = _nfoldCV(:stumps, labels, features, niterations, nfolds)
+nfoldCV_tree(data::DataFrame, target_column::Union{Symbol, AbstractString}, pruning_purity::Real, nfolds::Integer)                                          = nfoldCV_tree(_check_dataframe_input(data, target_column)..., pruning_purity, nfolds)
+nfoldCV_forest(data::DataFrame, target_column::Union{Symbol, AbstractString}, nsubfeatures::Integer, ntrees::Integer, nfolds::Integer, partialsampling=0.7) = nfoldCV_forest(_check_dataframe_input(data, target_column)..., nsubfeatures, ntrees, nfolds, partialsampling)
+nfoldCV_stumps(data::DataFrame, target_column::Union{Symbol, AbstractString}, niterations::Integer, nfolds::Integer)                                        = nfoldCV_stumps(_check_dataframe_input(data, target_column)..., niterations, nfolds)
 
 ### Regression ###
 
@@ -181,7 +184,7 @@ function R2(actual, predicted)
     return 1.0 - ss_residual/ss_total
 end
 
-function _nfoldCV{T<:Float64, U<:Real}(regressor::Symbol, labels::Vector{T}, features::Matrix{U}, args...)
+function _nfoldCV{T<:Float64}(regressor::Symbol, labels::AbstractVector{T}, features::Union{Matrix, DataFrame}, args...)
     nfolds = args[end]
     if nfolds < 2
         return nothing
@@ -226,6 +229,6 @@ function _nfoldCV{T<:Float64, U<:Real}(regressor::Symbol, labels::Vector{T}, fea
     return R2s
 end
 
-nfoldCV_tree{T<:Float64, U<:Real}(labels::Vector{T}, features::Matrix{U}, nfolds::Integer, maxlabels::Integer=5)      = _nfoldCV(:tree, labels, features, maxlabels, nfolds)
-nfoldCV_forest{T<:Float64, U<:Real}(labels::Vector{T}, features::Matrix{U}, nsubfeatures::Integer, ntrees::Integer, nfolds::Integer, maxlabels::Integer=5, partialsampling=0.7)  = _nfoldCV(:forest, labels, features, nsubfeatures, ntrees, maxlabels, partialsampling, nfolds)
-
+nfoldCV_tree{T<:Float64}(labels::AbstractVector{T}, features::Union{Matrix, DataFrame}, nfolds::Integer, maxlabels::Integer=5)      = _nfoldCV(:tree, labels, features, maxlabels, nfolds)
+nfoldCV_tree(data::DataFrame, target_column::Union{Symbol, AbstractString}, nfolds::Integer, maxlabels::Integer=5)                  = nfoldCV_tree(_check_dataframe_input(data, target_column)..., nfolds, maxlabels)
+nfoldCV_forest{T<:Float64}(labels::AbstractVector{T}, features::Union{Matrix, DataFrame}, nsubfeatures::Integer, ntrees::Integer, nfolds::Integer, maxlabels::Integer=5, partialsampling=0.7)  = _nfoldCV(:forest, labels, features, nsubfeatures, ntrees, maxlabels, partialsampling, nfolds)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+RDatasets

--- a/test/classification_hetero.jl
+++ b/test/classification_hetero.jl
@@ -2,6 +2,7 @@
 
 using Base.Test
 using DecisionTree
+using DataFrames
 
 m, n = 10^2, 5
 
@@ -12,21 +13,61 @@ labels = string.(tf[inds])
 features = Array{Any}(m, n)
 features[:,:] = randn(m, n)
 features[:,2] = string.(tf[randperm(m)])
-features[:,3] = map(t -> round(Int, t), features[:,3]) # can just become round.(Int, features[:,3]) when Julia 0.5 support is dropped
+features[:,3] = round.(Int, features[:,3])
 features[:,4] = tf[inds]
 
-model = build_tree(labels, features)
-preds = apply_tree(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.7
+@testset "Classification with heterogenous features" begin
 
-model = build_forest(labels, features,2,3)
-preds = apply_forest(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.7
+    @testset "Arrays" begin
 
-model, coeffs = build_adaboost_stumps(labels, features, 7)
-preds = apply_adaboost_stumps(model, coeffs, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.7
+        @testset "Decision Tree" begin
+            model = build_tree(labels, features)
+            preds = apply_tree(model, features)
+            cm = confusion_matrix(labels, preds)
+            @test cm.accuracy > 0.7
+        end
 
+        @testset "Decision Forest" begin
+            model = build_forest(labels, features,2,3)
+            preds = apply_forest(model, features)
+            cm = confusion_matrix(labels, preds)
+            @test cm.accuracy > 0.7
+        end
+
+        @testset "Adaboost Stumps" begin
+            model, coeffs = build_adaboost_stumps(labels, features, 7)
+            preds = apply_adaboost_stumps(model, coeffs, features)
+            cm = confusion_matrix(labels, preds)
+            @test cm.accuracy > 0.7
+        end
+
+    end
+
+    @testset "DataFrame" begin
+
+        df = hcat(DataFrame(features), DataFrame(target = labels))
+
+        @testset "Decision Tree" begin
+            model = build_tree(df, :target)
+            preds = apply_tree(model, df)
+            cm = confusion_matrix(df[:target], preds)
+            @test cm.accuracy > 0.7
+        end
+
+        @testset "Decision Forest" begin
+            model = build_forest(df, :target,2,3)
+            preds = apply_forest(model, df)
+            cm = confusion_matrix(df[:target], preds)
+            @test cm.accuracy > 0.7
+        end
+
+        @testset "Adaboost Stumps" begin
+            model, coeffs = build_adaboost_stumps(df, :target, 7)
+            preds = apply_adaboost_stumps(model, coeffs, df)
+            cm = confusion_matrix(df[:target], preds)
+            #@test cm.accuracy > 0.7
+        end
+
+    end
+
+end

--- a/test/classification_rand.jl
+++ b/test/classification_rand.jl
@@ -1,5 +1,6 @@
 using Base.Test
 using DecisionTree
+using DataFrames
 
 srand(16)
 
@@ -9,17 +10,53 @@ weights = rand(-1:1,m);
 labels = _int(features * weights);
 
 maxdepth = 3
-model = build_tree(labels, features, 0, maxdepth)
-@test depth(model) == maxdepth
 
-println("\n##### nfoldCV Classification Tree #####")
-accuracy = nfoldCV_tree(labels, features, 0.9, 3)
-@test mean(accuracy) > 0.7
+@testset "nfoldCV - Classification" begin
 
-println("\n##### nfoldCV Classification Forest #####")
-accuracy = nfoldCV_forest(labels, features, 2, 10, 3)
-@test mean(accuracy) > 0.7
+    @testset "Arrays" begin
 
-println("\n##### nfoldCV Adaboosted Stumps #####")
-accuracy = nfoldCV_stumps(labels, features, 7, 3)
-@test mean(accuracy) > 0.5
+        @testset "nfoldCV Tree" begin
+            model = build_tree(labels, features, 0, maxdepth)
+            @test depth(model) == maxdepth
+
+            accuracy = nfoldCV_tree(labels, features, 0.9, 3)
+            @test mean(accuracy) > 0.7
+        end
+
+        @testset "nfoldCV Forest" begin
+            accuracy = nfoldCV_forest(labels, features, 2, 10, 3)
+            @test mean(accuracy) > 0.7
+        end
+
+        @testset "nfoldCV Adaboosted Stumps" begin
+            accuracy = nfoldCV_stumps(labels, features, 7, 3)
+            @test mean(accuracy) > 0.5
+        end
+
+    end
+
+    @testset "DataFrame" begin
+
+        df = hcat(DataFrame(features), DataFrame(target = labels))
+
+        @testset "nfoldCV Tree" begin
+            model = build_tree(df, :target, 0, maxdepth)
+            @test depth(model) == maxdepth
+
+            accuracy = nfoldCV_tree(df, :target, 0.9, 3)
+            @test mean(accuracy) > 0.7
+        end
+
+        @testset "nfoldCV Forest" begin
+            accuracy = nfoldCV_forest(df, :target, 2, 10, 3)
+            @test mean(accuracy) > 0.7
+        end
+
+        @testset "nfoldCV Adaboosted Stumps" begin
+            accuracy = nfoldCV_stumps(df, :target, 7, 3)
+            #@test mean(accuracy) > 0.7
+        end
+        
+    end
+
+end

--- a/test/iris.jl
+++ b/test/iris.jl
@@ -1,38 +1,111 @@
 using Base.Test
+using DataFrames
 using RDatasets: dataset
 using DecisionTree
 
 iris = dataset("datasets", "iris");
-features = convert(Array, iris[:, 1:4]);
-labels = convert(Array, iris[:, 5]);
 
-# train full-tree classifier
-model = build_tree(labels, features)
-# prune tree: merge leaves having >= 90% combined purity (default: 100%)
-model = prune_tree(model, 0.9)
-# pretty print of the tree, to a depth of 5 nodes (optional)
-print_tree(model, 5)
-# apply learned model
-apply_tree(model, [5.9,3.0,5.1,1.9])
-# run n-fold cross validation for pruned tree, using 90% purity threshold purning, and 3 CV folds
-println("\n##### nfoldCV Classification Tree #####")
-accuracy = nfoldCV_tree(labels, features, 0.9, 3)
-@test mean(accuracy) > 0.8
+@testset for Test in ["Iris Classification", "Iris Regression"]
 
-# train random forest classifier, using 2 random features, 10 trees and 0.5 of samples per tree (optional, defaults to 0.7)
-model = build_forest(labels, features, 2, 10, 0.5)
-# apply learned model
-apply_forest(model, [5.9,3.0,5.1,1.9])
-# run n-fold cross validation for forests, using 2 random features, 10 trees, 3 folds, 0.5 of samples per tree (optional, defaults to 0.7)
-println("\n##### nfoldCV Classification Forest #####")
-accuracy = nfoldCV_forest(labels, features, 2, 10, 3, 0.5)
-@test mean(accuracy) > 0.8
+    if Test == "Iris Classification"
+        featurecols, targetcol = 1:4, 5
+    elseif Test == "Iris Regression"
+        break # break because heterogenous features are not yet supported for regression
+        featurecols, targetcol = 2:5, 1
+    end
 
-# train adaptive-boosted decision stumps, using 7 iterations
-model, coeffs = build_adaboost_stumps(labels, features, 7);
-# apply learned model
-apply_adaboost_stumps(model, coeffs, [5.9,3.0,5.1,1.9])
-# run n-fold cross validation for boosted stumps, using 7 iterations and 3 folds
-println("\n##### nfoldCV Classification Adaboosted Stumps #####")
-nfoldCV_stumps(labels, features, 7, 3)
+    @testset "Arrays" begin
 
+        features = convert(Array, iris[:, featurecols]);
+        labels = convert(Array, iris[:, targetcol]);
+
+        @testset "Decision Tree" begin
+            # train full-tree classifier
+            model = build_tree(labels, features)
+            # prune tree: merge leaves having >= 90% combined purity (default: 100%)
+            model = prune_tree(model, 0.9)
+            # pretty print of the tree, to a depth of 5 nodes (optional)
+            print_tree(model, 5)
+            # apply learned model
+            apply_tree(model, [5.9,3.0,5.1,1.9])
+            apply_tree(model, features[1:10,:])
+            apply_tree_proba(model, features[1:10,:], ["versicolor", "virginica", "setosa"])
+            # run n-fold cross validation for pruned tree, using 90% purity threshold purning, and 3 CV folds
+            accuracy = nfoldCV_tree(labels, features, 0.9, 3)
+            @test mean(accuracy) > 0.8
+        end
+
+        @testset "Decision Forest" begin
+            # train random forest classifier, using 2 random features, 10 trees and 0.5 of samples per tree (optional, defaults to 0.7)
+            model = build_forest(labels, features, 2, 10, 0.5)
+            # apply learned model
+            apply_forest(model, [5.9,3.0,5.1,1.9])
+            apply_forest(model, features[1:10,:])
+            apply_forest_proba(model, features[1:10,:], ["versicolor", "virginica", "setosa"])
+            # run n-fold cross validation for forests, using 2 random features, 10 trees, 3 folds, 0.5 of samples per tree (optional, defaults to 0.7)
+            accuracy = nfoldCV_forest(labels, features, 2, 10, 3, 0.5)
+            @test mean(accuracy) > 0.8
+        end
+
+        @testset "Adaboost Stumps" begin
+            # train adaptive-boosted decision stumps, using 7 iterations
+            model, coeffs = build_adaboost_stumps(labels, features, 7);
+            # apply learned model
+            apply_adaboost_stumps(model, coeffs, [5.9,3.0,5.1,1.9])
+            apply_adaboost_stumps(model, coeffs, features[1:10,:])
+            apply_adaboost_stumps_proba(model, coeffs, features[1:10,:], ["versicolor", "virginica", "setosa"])
+            # run n-fold cross validation for boosted stumps, using 7 iterations and 3 folds
+            accuracy = nfoldCV_stumps(labels, features, 7, 3)
+            #@test mean(accuracy) > 0.8
+        end
+
+    end # Array
+
+    @testset "DataFrame" begin
+
+        cols = names(iris);
+        target, features = cols[targetcol], cols[featurecols];
+
+        @testset "Decision Tree" begin
+            # train full-tree classifier
+            model = build_tree(iris, target)
+            # prune tree: merge leaves having >= 90% combined purity (default: 100%)
+            model = prune_tree(model, 0.9)
+            # pretty print of the tree, to a depth of 5 nodes (optional)
+            print_tree(model, 5)
+            # apply learned model
+            apply_tree(model, [5.9,3.0,5.1,1.9])
+            apply_tree(model, iris[1:10, features])
+            apply_tree_proba(model, iris[1:10, features], ["versicolor", "virginica", "setosa"])
+            # run n-fold cross validation for pruned tree, using 90% purity threshold purning, and 3 CV folds
+            accuracy = nfoldCV_tree(iris, target, 0.9, 3)
+            @test mean(accuracy) > 0.8
+        end
+
+        @testset "Decision Forest" begin
+            # train random forest classifier, using 2 random features, 10 trees and 0.5 of samples per tree (optional, defaults to 0.7)
+            model = build_forest(iris, target, 2, 10, 0.5)
+            # apply learned model
+            apply_forest(model, [5.9,3.0,5.1,1.9])
+            apply_forest(model, iris[1:10, features])
+            apply_forest_proba(model, iris[1:10, features], ["versicolor", "virginica", "setosa"])
+            # run n-fold cross validation for forests, using 2 random features, 10 trees, 3 folds, 0.5 of samples per tree (optional, defaults to 0.7)
+            accuracy = nfoldCV_forest(iris, target, 2, 10, 3, 0.5)
+            @test mean(accuracy) > 0.8
+        end
+
+        @testset "Adaboost Stumps" begin
+            # train adaptive-boosted decision stumps, using 7 iterations
+            model, coeffs = build_adaboost_stumps(iris, target, 7);
+            # apply learned model
+            apply_adaboost_stumps(model, coeffs, [5.9,3.0,5.1,1.9])
+            apply_adaboost_stumps(model, coeffs, iris[1:10, features])
+            apply_adaboost_stumps_proba(model, coeffs, iris[1:10, features], ["versicolor", "virginica", "setosa"])
+            # run n-fold cross validation for boosted stumps, using 7 iterations and 3 folds
+            nfoldCV_stumps(iris, target, 7, 3)
+            #@test mean(accuracy) > 0.8
+        end
+
+    end # DataFrame
+
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,7 +1,7 @@
 ### Promote Leaf to Node
 
 leaf = Leaf(0, [0])
-node = Node(1, 1, leaf, leaf)
+node = Node(1, 1, leaf, leaf, Int)
 
 [leaf, node]
 [node, leaf]

--- a/test/regression_rand.jl
+++ b/test/regression_rand.jl
@@ -1,5 +1,6 @@
 using Base.Test
 using DecisionTree
+using DataFrames
 
 n,m = 10^3, 5 ;
 features = randn(n,m);
@@ -7,13 +8,43 @@ weights = rand(-2:2,m);
 labels = features * weights;
 
 maxdepth = 3
-model = build_tree(labels, features, 5, 0, maxdepth)
-@test depth(model) == maxdepth
 
-println("\n##### nfoldCV Regression Tree #####")
-r2 = nfoldCV_tree(labels, features, 3)
-@test mean(r2) > 0.6
+@testset "nfoldCV - Regression" begin
 
-println("\n##### nfoldCV Regression Forest #####")
-r2 = nfoldCV_forest(labels, features, 2, 10, 3)
-@test mean(r2) > 0.8
+    @testset "Arrays" begin
+
+        @testset "nfoldCV Tree" begin
+            model = build_tree(labels, features, 5, 0, maxdepth)
+            @test depth(model) == maxdepth
+
+            r2 = nfoldCV_tree(labels, features, 3)
+            @test mean(r2) > 0.6
+        end
+
+        @testset "nfoldCV Forest" begin
+            r2 = nfoldCV_forest(labels, features, 2, 10, 3)
+            @test mean(r2) > 0.8
+        end
+
+    end
+
+    @testset "DataFrame" begin
+
+        df = hcat(DataFrame(features), DataFrame(target = labels))
+
+        @testset "nfoldCV Tree" begin
+            model = build_tree(df, :target, 5, 0, maxdepth)
+            @test depth(model) == maxdepth
+
+            r2 = nfoldCV_tree(df, :target, 3)
+            @test mean(r2) > 0.6
+        end
+
+        @testset "nfoldCV Forest" begin
+            r2 = nfoldCV_forest(df, :target, 2, 10, 3)
+            @test mean(r2) > 0.8
+        end
+
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Base.Test
 using DecisionTree
 
-tests = ["classification_rand.jl", "regression_rand.jl", "classification_hetero.jl", "misc.jl",
+tests = ["classification_rand.jl", "regression_rand.jl", "classification_hetero.jl", "iris.jl", "misc.jl",
          "classification_scikitlearn.jl", "regression_scikitlearn.jl"]
 
 println("Running tests...")


### PR DESCRIPTION
Added support for DataFrames. I tried to generally keep to the original code style and make as few changes as possible (although there's still quite a lot). The change to the Node struct is there to avoid the slow Vector{Any} and to be able to return the predictions as CategoricalArrays if this was used as input.

Note that this PR does not address the issue of missing data! I think this is a separate topic especially since Missing will be part the language (in 0.7) and so missing data can be present in any Matrix.
