### PR TITLE
Replace `L` by `<` and `R` by `≥`

### DIFF
--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -102,13 +102,13 @@ in the training data that ended up here were of class 5."
 
 # Example output:
 ```
-Feature 3, Threshold -28.156052806422238
-< then Feature 2, Threshold -161.04351901384842
-    < then 5 : 842/3650
-    ≥ then 7 : 2493/10555
-≥ then Feature 7, Threshold 108.1408338577021
-    < then 2 : 2434/15287
-    ≥ then 8 : 1227/3508
+Feature 3 < -28.156052806422238 ?
+├─ Feature 2 < -161.04351901384842 ?
+   ├─ 5 : 842/3650
+   └─ 7 : 2493/10555
+└─ Feature 7 < 108.1408338577021 ?
+   ├─ 2 : 2434/15287
+   └─ 8 : 1227/3508
 ```
 
 To facilitate visualisation of trees using third party packages, a `DecisionTree.Leaf` object or 
@@ -121,13 +121,13 @@ function print_tree(tree::Node, depth=-1, indent=0; feature_names=nothing)
         return
     end
     if feature_names === nothing
-        println("Feature $(tree.featid), Threshold $(tree.featval)")
+        println("Feature $(tree.featid) < $(tree.featval)")
     else
-        println("Feature $(tree.featid): \"$(feature_names[tree.featid])\", Threshold $(tree.featval)")
+        println("Feature $(tree.featid): \"$(feature_names[tree.featid])\" < $(tree.featval)")
     end
-    print("    " ^ indent * "< then ")
+    print("    " ^ indent * "├─ ")
     print_tree(tree.left, depth, indent + 1; feature_names = feature_names)
-    print("    " ^ indent * "≥ then ")
+    print("    " ^ indent * "└─ ")
     print_tree(tree.right, depth, indent + 1; feature_names = feature_names)
 end
 

--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -90,25 +90,25 @@ end
        print_tree(tree::Node, depth=-1, indent=0; feature_names=nothing)
 
 Print a textual visualization of the given decision tree `tree`.
-In the example output below, the top node considers whether 
+In the example output below, the top node considers whether
 "Feature 3" is above or below the threshold -28.156052806422238.
-If the value of "Feature 3" is strictly below the threshold for some input to be classified, 
-we move to the `L->` part underneath, which is a node 
+If the value of "Feature 3" is strictly below the threshold for some input to be classified,
+we move to the `L->` part underneath, which is a node
 looking at if "Feature 2" is above or below -161.04351901384842.
-If the value of "Feature 2" is strictly below the threshold for some input to be classified, 
-we end up at `L-> 5 : 842/3650`. This is to be read as "In the left split, 
-the tree will classify the input as class 5, as 842 of the 3650 datapoints 
+If the value of "Feature 2" is strictly below the threshold for some input to be classified,
+we end up at `L-> 5 : 842/3650`. This is to be read as "In the left split,
+the tree will classify the input as class 5, as 842 of the 3650 datapoints
 in the training data that ended up here were of class 5."
 
 # Example output:
 ```
 Feature 3, Threshold -28.156052806422238
-L-> Feature 2, Threshold -161.04351901384842
-    L-> 5 : 842/3650
-    R-> 7 : 2493/10555
-R-> Feature 7, Threshold 108.1408338577021
-    L-> 2 : 2434/15287
-    R-> 8 : 1227/3508
+< then Feature 2, Threshold -161.04351901384842
+    < then 5 : 842/3650
+    ≥ then 7 : 2493/10555
+≥ then Feature 7, Threshold 108.1408338577021
+    < then 2 : 2434/15287
+    ≥ then 8 : 1227/3508
 ```
 
 To facilitate visualisation of trees using third party packages, a `DecisionTree.Leaf` object or 
@@ -125,9 +125,9 @@ function print_tree(tree::Node, depth=-1, indent=0; feature_names=nothing)
     else
         println("Feature $(tree.featid): \"$(feature_names[tree.featid])\", Threshold $(tree.featval)")
     end
-    print("    " ^ indent * "L-> ")
+    print("    " ^ indent * "< then ")
     print_tree(tree.left, depth, indent + 1; feature_names = feature_names)
-    print("    " ^ indent * "R-> ")
+    print("    " ^ indent * "≥ then ")
     print_tree(tree.right, depth, indent + 1; feature_names = feature_names)
 end
 


### PR DESCRIPTION
This PR is a suggestion to make the print output of `print_tree` easier to understand without context.

## Before (`dev` branch)

```
Feature 3, Threshold -28.166052806422238
L-> Feature 2, Threshold -161.04351901384842
    L-> 5 : 842/3650
    R-> 7 : 2493/10555
R-> Feature 7, Threshold 108.1408338577021
    L-> 2 : 2434/15287
    R-> 8 : 1227/3508
```

## After (this PR)

```
Feature 3 < -28.156052806422238 ?
├─ Feature 2 < -161.04351901384842 ?
   ├─ 5 : 842/3650
   └─ 7 : 2493/10555
└─ Feature 7 < 108.1408338577021 ?
   ├─ 2 : 2434/15287
   └─ 8 : 1227/3508
```