### PR TITLE
Fix type piracy on `zero`

### DIFF
--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -56,8 +56,9 @@ end
 is_leaf(l::Leaf) = true
 is_leaf(n::Node) = false
 
-zero(::Type{String}) = ""
-convert(::Type{Node{S, T}}, lf::Leaf{T}) where {S, T} = Node(0, zero(S), lf, Leaf(zero(T), [zero(T)]))
+_zero(::Type{String}) = ""
+_zero(x::Any) = zero(x)
+convert(::Type{Node{S, T}}, lf::Leaf{T}) where {S, T} = Node(0, _zero(S), lf, Leaf(_zero(T), [_zero(T)]))
 convert(::Type{Root{S, T}}, node::LeafOrNode{S, T}) where {S, T} = Root{S, T}(node, 0, Float64[])
 convert(::Type{LeafOrNode{S, T}}, tree::Root{S, T}) where {S, T} = tree.node
 promote_rule(::Type{Node{S, T}}, ::Type{Leaf{T}}) where {S, T} = Node{S, T}


### PR DESCRIPTION
This fixes the type piracy on `zero`. In #182, @yufongpeng has correctly changed

```julia
zero(String) = ""
```
to
```julia
zero(::Type{String}) = ""
```
because with the old implementation in DecisionTree 0.10, the following happens
```julia
julia> using Statistics

julia> mean([[1, 2]]; dims=1)
1-element Vector{Vector{Float64}}:
 [1.0, 2.0]

julia> using DecisionTree

julia> mean([[1, 2]]; dims=1)
ERROR: MethodError: no method matching +(::String, ::String)
[...]
```
since
```julia
julia> zero(String) = ""

julia> zero(1)
""
```
which used to be a very bad type piracy which was luckily solved already by Yu-Fong, Peng.

However, it's still a type piracy because `String` is not owned by `DecisionTree`.

Let's go for some extra safety by adding an intermediate function. 
