### PR TITLE
Adapt to new `AbstractNode` in `AbstractTrees`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ styleguide.txt
 makefile
 .DS_Store
 Manifest.toml
+.vscode

--- a/src/abstract_trees.jl
+++ b/src/abstract_trees.jl
@@ -15,6 +15,8 @@ in "Towards Data Science":
 ["If things are not ready to use"](https://towardsdatascience.com/part-iii-if-things-are-not-ready-to-use-59d2db378bec)
 """
 
+using AbstractNode      # temporary workaround until this type is available via `AbstractTrees.jl`
+
 
 """
     InfoNode{S, T}
@@ -30,12 +32,12 @@ In analogy to the type definitions of `DecisionTree`, the generic type `S` is
 the type of the feature values used within a node as a threshold for the splits
 between its children and `T` is the type of the classes given (these might be ids or labels).
 """
-struct InfoNode{S, T}
+struct InfoNode{S, T} <: AbstractNode
     node    :: DecisionTree.Node{S, T}
     info    :: NamedTuple
 end
 
-struct InfoLeaf{T}
+struct InfoLeaf{T} <: AbstractNode
     leaf    :: DecisionTree.Leaf{T}
     info    :: NamedTuple
 end

--- a/src/abstract_trees.jl
+++ b/src/abstract_trees.jl
@@ -15,9 +15,6 @@ in "Towards Data Science":
 ["If things are not ready to use"](https://towardsdatascience.com/part-iii-if-things-are-not-ready-to-use-59d2db378bec)
 """
 
-using AbstractNode      # temporary workaround until this type is available via `AbstractTrees.jl`
-
-
 """
     InfoNode{S, T}
     InfoLeaf{T}
@@ -32,15 +29,17 @@ In analogy to the type definitions of `DecisionTree`, the generic type `S` is
 the type of the feature values used within a node as a threshold for the splits
 between its children and `T` is the type of the classes given (these might be ids or labels).
 """
-struct InfoNode{S, T} <: AbstractNode
+struct InfoNode{S, T} <: AbstractTrees.AbstractNode{DecisionTree.Node{S,T}}
     node    :: DecisionTree.Node{S, T}
     info    :: NamedTuple
 end
+AbstractTrees.nodevalue(n::InfoNode) = n.node
 
-struct InfoLeaf{T} <: AbstractNode
+struct InfoLeaf{T} <: AbstractTrees.AbstractNode{DecisionTree.Leaf{T}}
     leaf    :: DecisionTree.Leaf{T}
     info    :: NamedTuple
 end
+AbstractTrees.nodevalue(l::InfoLeaf) = l.leaf
 
 """
     wrap(node::DecisionTree.Node, info = NamedTuple())


### PR DESCRIPTION
As there is now an abstract type `AbstractNode` in `AbstractTrees.jl` the "wrapped" decision tree (or rather its nodes) is now defined as a subtype of this `AbstractNode` so that dispatch on this type is possible when the tree gets plotted via a plot recipe.