### PR TITLE
Improved label printing/plotting of nodes/leaves

### DIFF
--- a/src/abstract_trees.jl
+++ b/src/abstract_trees.jl
@@ -133,7 +133,7 @@ function AbstractTrees.printnode(io::IO, leaf::InfoLeaf; sigdigits=4)
         @assert dt_leaf.majority isa Integer "classes must be represented as Integers"
         print(io, leaf.info.classlabels[dt_leaf.majority], " ($match_count/$val_count)")
     else
-	    print(io, typeof(dt_leaf.majority) <: Integer ? "Class: " : "", 
+	    print(io, dt_leaf.majority isa Integer ? "Class: " : "", 
             dt_leaf.majority, " ($match_count/$val_count)")
     end
 end

--- a/src/abstract_trees.jl
+++ b/src/abstract_trees.jl
@@ -130,7 +130,7 @@ function AbstractTrees.printnode(io::IO, leaf::InfoLeaf; sigdigits=4)
 	match_count = length(matches)
 	val_count   = length(dt_leaf.values)
     if :classlabels ∈ keys(leaf.info)
-        @assert typeof(dt_leaf.majority) <: Integer "classes must be represented as Integers"
+        @assert dt_leaf.majority isa Integer "classes must be represented as Integers"
         print(io, leaf.info.classlabels[dt_leaf.majority], " ($match_count/$val_count)")
     else
 	    print(io, typeof(dt_leaf.majority) <: Integer ? "Class: " : "", 

--- a/src/abstract_trees.jl
+++ b/src/abstract_trees.jl
@@ -28,6 +28,10 @@ apart from the two points mentioned.
 In analogy to the type definitions of `DecisionTree`, the generic type `S` is 
 the type of the feature values used within a node as a threshold for the splits
 between its children and `T` is the type of the classes given (these might be ids or labels).
+
+Please note: You may only add lacking class labels. It's not possible to overwrite  
+existing labels with this mechanism. In case you want add class labels, 
+the generic type `T` must be a subtype of `Integer`.
 """
 struct InfoNode{S, T} <: AbstractTrees.AbstractNode{DecisionTree.Node{S,T}}
     node    :: DecisionTree.Node{S, T}
@@ -126,6 +130,7 @@ function AbstractTrees.printnode(io::IO, leaf::InfoLeaf; sigdigits=4)
 	match_count = length(matches)
 	val_count   = length(dt_leaf.values)
     if :classlabels ∈ keys(leaf.info)
+        @assert typeof(dt_leaf.majority) <: Integer "classes must be represented as Integers"
         print(io, leaf.info.classlabels[dt_leaf.majority], " ($match_count/$val_count)")
     else
 	    print(io, "Class: ", dt_leaf.majority, " ($match_count/$val_count)")

--- a/src/abstract_trees.jl
+++ b/src/abstract_trees.jl
@@ -108,16 +108,19 @@ For the condition of the form `feature < value` which gets printed in the `print
 variant for `InfoNode`, the left subtree is the 'yes-branch' and the right subtree
 accordingly the 'no-branch'. `AbstractTrees.print_tree` outputs the left subtree first
 and then below the right subtree.
+
+`value` gets rounded to `sigdigits` significant digits.
 """
-function AbstractTrees.printnode(io::IO, node::InfoNode)
+function AbstractTrees.printnode(io::IO, node::InfoNode; sigdigits=4)
+    featval = round(node.node.featval; sigdigits)
     if :featurenames ∈ keys(node.info) 
-        print(io, node.info.featurenames[node.node.featid], " < ", node.node.featval)
+        print(io, node.info.featurenames[node.node.featid], " < ", featval)
     else
-	    print(io, "Feature: ", node.node.featid, " < ", node.node.featval)
+	    print(io, "Feature: ", node.node.featid, " < ", featval)
     end
 end
 
-function AbstractTrees.printnode(io::IO, leaf::InfoLeaf)
+function AbstractTrees.printnode(io::IO, leaf::InfoLeaf; sigdigits=4)
     dt_leaf = leaf.leaf
     matches     = findall(dt_leaf.values .== dt_leaf.majority)
 	match_count = length(matches)

--- a/src/abstract_trees.jl
+++ b/src/abstract_trees.jl
@@ -94,8 +94,8 @@ AbstractTrees.children(node::InfoNode) = (
 AbstractTrees.children(node::InfoLeaf) = ()
 
 """
-    printnode(io::IO, node::InfoNode)
-    printnode(io::IO, leaf::InfoLeaf)
+    printnode(io::IO, node::InfoNode; sigdigits=4)
+    printnode(io::IO, leaf::InfoLeaf; sigdigits=4)
 
 Write a printable representation of `node` or `leaf` to output-stream `io`.
 

--- a/src/abstract_trees.jl
+++ b/src/abstract_trees.jl
@@ -133,6 +133,7 @@ function AbstractTrees.printnode(io::IO, leaf::InfoLeaf; sigdigits=4)
         @assert typeof(dt_leaf.majority) <: Integer "classes must be represented as Integers"
         print(io, leaf.info.classlabels[dt_leaf.majority], " ($match_count/$val_count)")
     else
-	    print(io, "Class: ", dt_leaf.majority, " ($match_count/$val_count)")
+	    print(io, typeof(dt_leaf.majority) <: Integer ? "Class: " : "", 
+            dt_leaf.majority, " ($match_count/$val_count)")
     end
 end

--- a/src/abstract_trees.jl
+++ b/src/abstract_trees.jl
@@ -29,9 +29,10 @@ In analogy to the type definitions of `DecisionTree`, the generic type `S` is
 the type of the feature values used within a node as a threshold for the splits
 between its children and `T` is the type of the classes given (these might be ids or labels).
 
-Please note: You may only add lacking class labels. It's not possible to overwrite  
-existing labels with this mechanism. In case you want add class labels, 
-the generic type `T` must be a subtype of `Integer`.
+    !!! note
+    You may only add lacking class labels. It's not possible to overwrite existing labels
+    with this mechanism. In case you want add class labels, the generic type `T` must 
+    be a subtype of `Integer`.
 """
 struct InfoNode{S, T} <: AbstractTrees.AbstractNode{DecisionTree.Node{S,T}}
     node    :: DecisionTree.Node{S, T}

--- a/test/miscellaneous/abstract_trees_test.jl
+++ b/test/miscellaneous/abstract_trees_test.jl
@@ -82,3 +82,22 @@ traverse_tree(leaf::InfoLeaf) = nothing
 
 traverse_tree(wrapped_tree)
 end
+
+@testset "abstract_trees - test misuse" begin
+
+    @info("Test misuse of `classlabel` information") 
+
+    @info("Create test data - a decision tree based on the iris data set") 
+    features, labels = load_data("iris") 
+    features = float.(features)
+    labels   = string.(labels)
+    model = DecisionTreeClassifier()
+    fit!(model, features, labels)    
+
+    @info("Try to replace the exisitng class labels")
+    class_labels = unique(labels)
+    dtree = model.root.node
+    wt = DecisionTree.wrap(dtree, (classlabels = class_labels,))
+    @test_throws AssertionError AbstractTrees.print_tree(wt)
+
+end


### PR DESCRIPTION
- `printnode` is now rounding the thresholds to `sigdigits` significant digits (`sigdigits` is a keyword parameter)
- the label "Class: " is only printed/plotted within leaves, if ids are used as 'class names'
- a clarification and a check has been added, that you cannot add class names with `wrap` if there are already class names in use (i.e. existing class names cannot be _overriden_, they can only be _added_ if ids are used within the original decision tree structure).