### PR TITLE
Add method `build_forest(model, ...)` to add trees to existing `model`

### DIFF
--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -52,7 +52,6 @@ struct Ensemble{S, T}
     featim  :: Vector{Float64}
 end
 
-
 is_leaf(l::Leaf) = true
 is_leaf(n::Node) = false
 
@@ -70,6 +69,8 @@ promote_rule(::Type{Leaf{T}}, ::Type{Root{S, T}}) where {S, T} = Root{S, T}
 promote_rule(::Type{Root{S, T}}, ::Type{Node{S, T}}) where {S, T} = Root{S, T}
 promote_rule(::Type{Node{S, T}}, ::Type{Root{S, T}}) where {S, T} = Root{S, T}
 
+const DOC_ENSEMBLE =
+    "`DecisionTree.Ensemble` objects are returned by, for example, `build_forest`."
 const ERR_ENSEMBLE_VCAT = DimensionMismatch(
     "Ensembles that record feature impurity importances cannot be combined when "*
         "they were generated using differing numbers of features. "
@@ -78,11 +79,18 @@ const ERR_ENSEMBLE_VCAT = DimensionMismatch(
 """
     DecisionTree.has_impurity_importance(ensemble::Ensemble)
 
-Returns `true` if `ensemble` stores impurity importances. `DecisionTree.Ensemble` objects
-are returned by, for example, `build_forest`.
+Returns `true` if `ensemble` stores impurity importances. $DOC_ENSEMBLE
 
 """
 has_impurity_importance(e::Ensemble) = !isempty(e.featim)
+
+"""
+    DecisionTree.n_features(ensemble::Ensemble)
+
+Return the number of features on which `ensemble` was trained. $DOC_ENSEMBLE
+
+"""
+n_features(ensemble::Ensemble) = ensemble.n_feat
 
 """
     vcat(e1::Ensemble{S,T}, e2::Ensemble{S,T})
@@ -105,6 +113,10 @@ function Base.vcat(e1::Ensemble{S,T}, e2::Ensemble{S,T}) where {S,T}
     end
     Ensemble{S,T}(trees, e2.n_feat, featim)
 end
+
+Base.getindex(ensemble::DecisionTree.Ensemble, I) =
+    DecisionTree.Ensemble(ensemble.trees[I], ensemble.n_feat, ensemble.featim)
+Base.length(ensemble::Ensemble) = length(ensemble.trees)
 
 # make a Random Number Generator object
 mk_rng(rng::Random.AbstractRNG) = rng

--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -96,7 +96,7 @@ n_features(ensemble::Ensemble) = ensemble.n_feat
     vcat(e1::Ensemble{S,T}, e2::Ensemble{S,T})
 
 Combine `DecisionTree.Ensemble` objects, such as random forests returned by
-`build_forest`. If `e1` or `e2` does not store feature importances, then neither will the
+`build_forest`. If `e1` or `e2` does not store impurity importances, then neither will the
 returned ensemble.
 
 """
@@ -111,6 +111,10 @@ function Base.vcat(e1::Ensemble{S,T}, e2::Ensemble{S,T}) where {S,T}
         e1.n_feat == e2.n_feat || throw(ERR_ENSEMBLE_VCAT)
         (n1 .* e1.featim + n2 .* e2.featim) ./ n
     end
+    # In the case where impurity importances are being dumped, we continue to propogate
+    # the feature count `n_feat` as seen in the second ensemble `e2`, although we are not
+    # checking this matches the count for `e1`. At time of writing, `n_feat` is only used
+    # in conjunction with impurity importance reporting, so this should be okay.
     Ensemble{S,T}(trees, e2.n_feat, featim)
 end
 

--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -58,8 +58,10 @@ is_leaf(n::Node) = false
 
 _zero(::Type{String}) = ""
 _zero(x::Any) = zero(x)
-convert(::Type{Node{S, T}}, lf::Leaf{T}) where {S, T} = Node(0, _zero(S), lf, Leaf(_zero(T), [_zero(T)]))
-convert(::Type{Root{S, T}}, node::LeafOrNode{S, T}) where {S, T} = Root{S, T}(node, 0, Float64[])
+convert(::Type{Node{S, T}}, lf::Leaf{T}) where {S, T} =
+    Node(0, _zero(S), lf, Leaf(_zero(T), [_zero(T)]))
+convert(::Type{Root{S, T}}, node::LeafOrNode{S, T}) where {S, T} =
+    Root{S, T}(node, 0, Float64[])
 convert(::Type{LeafOrNode{S, T}}, tree::Root{S, T}) where {S, T} = tree.node
 promote_rule(::Type{Node{S, T}}, ::Type{Leaf{T}}) where {S, T} = Node{S, T}
 promote_rule(::Type{Leaf{T}}, ::Type{Node{S, T}}) where {S, T} = Node{S, T}

--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -69,6 +69,12 @@ promote_rule(::Type{Leaf{T}}, ::Type{Root{S, T}}) where {S, T} = Root{S, T}
 promote_rule(::Type{Root{S, T}}, ::Type{Node{S, T}}) where {S, T} = Root{S, T}
 promote_rule(::Type{Node{S, T}}, ::Type{Root{S, T}}) where {S, T} = Root{S, T}
 
+const DOC_WHATS_A_TREE =
+    "Here `tree` is any `DecisionTree.Root`, `DecisionTree.Node` or "*
+    "`DecisionTree.Leaf` instance, as returned, for example, by [`build_tree`](@ref)."
+const DOC_WHATS_A_FOREST =
+    "Here `forest` is any `DecisionTree.Ensemble` instance, as returned, for "*
+    "example, by [`build_forest`](@ref)."
 const DOC_ENSEMBLE =
     "`DecisionTree.Ensemble` objects are returned by, for example, `build_forest`."
 const ERR_ENSEMBLE_VCAT = DimensionMismatch(

--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -116,7 +116,6 @@ end
 
 Base.getindex(ensemble::DecisionTree.Ensemble, I) =
     DecisionTree.Ensemble(ensemble.trees[I], ensemble.n_feat, ensemble.featim)
-Base.length(ensemble::Ensemble) = length(ensemble.trees)
 
 # make a Random Number Generator object
 mk_rng(rng::Random.AbstractRNG) = rng

--- a/src/classification/main.jl
+++ b/src/classification/main.jl
@@ -199,11 +199,11 @@ Prune tree based on prediction accuracy of each node.
   classification tree and regression tree, respectively. If the tree is not a `Root`, this
   argument does not affect the result.
 
-For a tree of type `Root`, when any of its nodes is pruned, the `featim` field will be
+For a tree of type `Root`, when any of its nodes are pruned, the `featim` field will be
 updated by recomputing the impurity decrease of that node divided by the total number of
 training observations and subtracting the value.  The computation of impurity decrease is
 based on node impurity calculated with the loss function provided as the argument
-`loss`. The algorithm is as same as that described in the `impurity_importance`
+`loss`. The algorithm is as same as that described in the [`impurity_importance`](@ref)
 documentation.
 
 This function will recurse until no stumps can be pruned.
@@ -570,10 +570,9 @@ function build_forest(
     # were stored previously) and if the number of features has also changed. So we catch
     # that before training new ensemble:
     n_features = size(features, 2)
-    !impurity_importance ||
-        n_features == DecisionTree.n_features(model) ||
-            throw(ERR_CANT_UPDATE_IMPURITY_IMPORTANCE)
-
+    if impurity_importance && n_features != DecisionTree.n_features(model)
+        throw(ERR_CANT_UPDATE_IMPURITY_IMPORTANCE)
+    end 
     new_forest = build_forest(
         labels,
         features,

--- a/src/classification/main.jl
+++ b/src/classification/main.jl
@@ -188,7 +188,7 @@ end
 """
     prune_tree(tree::Union{Root, LeafOrNode}, purity_thresh=1.0, loss::Function)
 
-Prune tree based on prediction accuracy of each node.
+Prune `tree` based on prediction accuracy of each node. $DOC_WHATS_A_TREE
 
 * `purity_thresh`: If the prediction accuracy of a stump is larger than this value, the node
   will be pruned and become a leaf.
@@ -208,8 +208,12 @@ documentation.
 
 This function will recurse until no stumps can be pruned.
 
-Warn:
+!!! warning
+
     For regression trees, pruning trees based on accuracy may not be an appropriate method.
+
+See also [`build_tree`](@ref).
+
 """
 function prune_tree(
     tree::Union{Root{S, T}, LeafOrNode{S, T}},
@@ -303,14 +307,16 @@ function apply_tree(tree::LeafOrNode{S, T}, features::AbstractMatrix{S}) where {
 end
 
 """
-    apply_tree_proba(::Root, features, col_labels::AbstractVector)
+    apply_tree_proba(tree, features, col_labels::AbstractVector)
 
-computes P(L=label|X) for each row in `features`. It returns a `N_row x
-n_labels` matrix of probabilities, each row summing up to 1.
+For the specified `tree`, compute ``P(L=label|X)`` for each row in `features`, returning
+an `N_row` x `n_labels` matrix of probabilities, each row summing to one. $DOC_WHATS_A_TREE
 
-`col_labels` is a vector containing the distinct labels
-(eg. ["versicolor", "virginica", "setosa"]). It specifies the column ordering
-of the output matrix.
+`col_labels` is a vector containing the distinct labels, eg. `["versicolor", "virginica",
+"setosa"]`. It's order determines the column ordering of the output matrix.
+
+See also [`build_tree`](@ref).
+
 """
 apply_tree_proba(tree::Root{S, T}, features::AbstractVector{S}, labels) where {S, T} =
     apply_tree_proba(tree.node, features, labels)
@@ -572,7 +578,7 @@ function build_forest(
     n_features = size(features, 2)
     if impurity_importance && n_features != DecisionTree.n_features(model)
         throw(ERR_CANT_UPDATE_IMPURITY_IMPORTANCE)
-    end 
+    end
     new_forest = build_forest(
         labels,
         features,
@@ -626,7 +632,7 @@ end
 """
     apply_forest(forest::Ensemble, features::AbstractMatrix; use_multithreading=false)
 
-Apply learned model `forest` to `features`.
+Apply learned model `forest` to `features`. $DOC_WHATS_A_FOREST
 
 # Keywords
 
@@ -654,12 +660,15 @@ end
 """
     apply_forest_proba(forest::Ensemble, features, col_labels::AbstractVector)
 
-computes P(L=label|X) for each row in `features`. It returns a `N_row x
-n_labels` matrix of probabilities, each row summing up to 1.
+For the specified `forest`, compute ``P(L=label|X)`` for each row in `features`, returning
+a `N_row` x `n_labels` matrix of probabilities, each row summing to
+one. $DOC_WHATS_A_FOREST
 
-`col_labels` is a vector containing the distinct labels
-(eg. ["versicolor", "virginica", "setosa"]). It specifies the column ordering
-of the output matrix.
+`col_labels` is a vector containing the distinct labels, eg. `["versicolor", "virginica",
+"setosa"]`. It's order determines the column ordering of the output matrix.
+
+See also [`build_forest`](@ref).
+
 """
 function apply_forest_proba(
     forest::Ensemble{S, T},
@@ -761,12 +770,14 @@ end
 """
     apply_adaboost_stumps_proba(stumps::Ensemble, coeffs, features, labels::AbstractVector)
 
-computes P(L=label|X) for each row in `features`. It returns a `N_row x
-n_labels` matrix of probabilities, each row summing up to 1.
+Compute ``P(L=label|X)`` for each row in `features`, returning a `N_row` x
+`n_labels` matrix of probabilities, each row summing to one.
 
-`col_labels` is a vector containing the distinct labels
-(eg. ["versicolor", "virginica", "setosa"]). It specifies the column ordering
-of the output matrix.
+`col_labels` is a vector containing the distinct labels, eg. `["versicolor", "virginica",
+"setosa"]`. Its ordering determines the column ordering of the output matrix.
+
+See also [`build_adaboost_stumps`](@ref). 
+
 """
 function apply_adaboost_stumps_proba(
     stumps::Ensemble{S, T},

--- a/src/classification/main.jl
+++ b/src/classification/main.jl
@@ -408,6 +408,77 @@ function build_forest(
     return _build_forest(forest, size(features, 2), n_trees, impurity_importance)
 end
 
+const ERR_CANT_UPDATE_IMPURITY_IMPORTANCE = DimensionMismatch(
+    "Looks like you want to add trees to a model previously trained using a "*
+        "different number of features, which means impurity importances "*
+        "cannot be updated. Fix by setting `impurity_importance=false`. "
+)
+
+"""
+    build_forest(model, labels, features, options...; keyword_options...)
+
+Return an updated version of `model` with additional `n_trees=options[2]` added to the
+forest. Here `options` and `keyword_options` are as for the regular `build_forest` method,
+which excludes the `model` argument.
+
+Even if training data is the same in all `build_forest` calls, it is not practically
+possible to guarantee adding trees in steps is identical to adding them all at once,
+because of the way random number generators are generated and used. But in all other
+respects these approaches are equivalent.
+
+# Example
+
+```
+features, labels = load_data("iris")
+features = float.(features)
+labels = string.(labels)
+```
+
+The call
+
+```
+model = build_forest(labels, features, 2, 200) # n_trees = 200
+```
+
+is approximately equivalent to
+
+```
+model1 = build_forest(labels, features, 2, 150) # n_trees = 150
+model = build_forest(model1, labels, features, 2, 50) # n_trees = 50
+```
+
+"""
+function build_forest(
+    model               :: Ensemble{S,T},
+    labels              :: AbstractVector{T},
+    features            :: AbstractMatrix{S},
+    options...;
+    impurity_importance=true,
+    kwoptions...,
+    ) where {S, T}
+
+    # Only compute impurity importances if requested and present in the existing ensemble:
+    impurity_importance = impurity_importance && has_impurity_importance(model)
+
+    # Combining forests will throw an error if feature importances are reqested now (and
+    # were stored previously) and if the number of features has also changed. So we catch
+    # that before training new ensemble:
+    n_features = size(features, 2)
+    !impurity_importance ||
+        n_features == DecisionTree.n_features(model) ||
+            throw(ERR_CANT_UPDATE_IMPURITY_IMPORTANCE)
+
+    new_forest = build_forest(
+        labels,
+        features,
+        options...;
+        impurity_importance,
+        kwoptions...)
+
+    # `model` and `new_forest` are both `Ensemble` objects:
+    return vcat(model, new_forest)
+end
+
 function _build_forest(
         forest              :: Vector{<:Union{Root{S,T},LeafOrNode{S,T}}},
         n_features          ,

--- a/test/classification/adding_trees.jl
+++ b/test/classification/adding_trees.jl
@@ -1,0 +1,35 @@
+# determine order of a numerical list, eg, [0.3, 0.1, 0.6, -0.1] -> [3, 2, 4, 1]
+function rank(v)
+    w = sort(collect(enumerate(v)), by=last)
+    return first.(w) |> invperm
+end
+
+features, labels = load_data("iris")
+features = float.(features)
+labels = string.(labels)
+classes = unique(labels)
+
+@testset "adding models in an ensemble" begin
+
+    n = 40   # n_trees in first step
+    Δn = 30  # n_trees to be added
+
+    one_step_model = build_forest(labels, features, 2, n + Δn; rng=srng())
+
+    model1 = build_forest(labels, features, 2, n; rng=srng())
+    two_step_model = build_forest(model1, labels, features, 2, Δn; rng=srng())
+
+    @test length(two_step_model) == n + Δn
+
+    # test the models agree on the initial portion of the ensemble:
+    @test apply_forest_proba(one_step_model[1:n], features, classes) ≈
+        apply_forest_proba(two_step_model[1:n], features, classes)
+
+    # smoke test - predictions are from the classes seen:
+    @test issubset(unique(apply_forest(two_step_model, features)),  classes)
+
+    # smoke test - one-step and two-step models predict the same feature rankings:
+    @test rank(impurity_importance(one_step_model)) ==
+        rank(impurity_importance(two_step_model))
+
+end

--- a/test/miscellaneous/ensemble_methods.jl
+++ b/test/miscellaneous/ensemble_methods.jl
@@ -1,0 +1,30 @@
+@testset "methods for `Ensemble` type" begin
+    features, labels = load_data("iris")
+
+    # combining identical ensembles:
+    ensemble1 = build_forest(labels, features, 2, 4)
+    ensemble = vcat(ensemble1, ensemble1)
+    @test DecisionTree.has_impurity_importance(ensemble1)
+    @test ensemble.featim ≈ ensemble1.featim
+
+    # combining heterogeneous ensembles:
+    ensemble2 = build_forest(labels, features, 2, 10)
+    ensemble = vcat(ensemble1, ensemble2)
+    n1 = length(ensemble1.trees)
+    n2 = length(ensemble2.trees)
+    n = n1 + n2
+    @test n*ensemble.featim ≈ n1*ensemble1.featim + n2*ensemble2.featim
+
+    # including an ensemble without impurity importance should drop impurity importance from
+    # the combination:
+    ensemble3 = build_forest(labels, features, 2, 4; impurity_importance=false)
+    @test !DecisionTree.has_impurity_importance(ensemble3)
+    @test vcat(ensemble1, ensemble3).featim == Float64[]
+    @test vcat(ensemble3, ensemble1).featim == Float64[]
+    @test vcat(ensemble3, ensemble3).featim == Float64[]
+
+    # changing the number of features:
+    ensemble4 = build_forest(labels, features[:, 1:3], 2, 4)
+    @test_logs vcat(ensemble3, ensemble4) # ensemble 3 doesn't support importances
+    @test_throws DecisionTree.ERR_ENSEMBLE_VCAT vcat(ensemble1, ensemble4)
+end

--- a/test/miscellaneous/ensemble_methods.jl
+++ b/test/miscellaneous/ensemble_methods.jl
@@ -2,9 +2,12 @@
     features, labels = load_data("iris")
 
     # combining identical ensembles:
-    ensemble1 = build_forest(labels, features, 2, 4)
-    ensemble = vcat(ensemble1, ensemble1)
+    ensemble1 = build_forest(labels, features, 2, 7)
     @test DecisionTree.has_impurity_importance(ensemble1)
+    @test ensemble1[1:2].trees == ensemble1.trees[1:2]
+    @test length(ensemble1) == 7
+    @test DecisionTree.n_features(ensemble1) == 4
+    ensemble = vcat(ensemble1, ensemble1)
     @test ensemble.featim ≈ ensemble1.featim
 
     # combining heterogeneous ensembles:
@@ -28,3 +31,4 @@
     @test_logs vcat(ensemble3, ensemble4) # ensemble 3 doesn't support importances
     @test_throws DecisionTree.ERR_ENSEMBLE_VCAT vcat(ensemble1, ensemble4)
 end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ using DecisionTree: confusion_matrix, ConfusionMatrix
 println("Julia version: ", VERSION)
 
 similarity(a, b) = first(reshape(a, 1, :) * b / norm(a) / norm(b))
+srng() = StableRNGs.StableRNG(123)
 
 function run_tests(list)
     for test in list
@@ -31,7 +32,8 @@ classification = [
     "classification/digits.jl",
     "classification/iris.jl",
     "classification/adult.jl",
-    "classification/scikitlearn.jl"
+    "classification/scikitlearn.jl",
+    "classification/adding_trees.jl",
 ]
 
 regression =     [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,7 @@ miscellaneous =  [
     "miscellaneous/convert.jl",
     "miscellaneous/abstract_trees_test.jl",
     "miscellaneous/feature_importance_test.jl",
+    "miscellaneous/ensemble_methods.jl",
 #    "miscellaneous/parallel.jl"
 
 ]


### PR DESCRIPTION
Closes #213.

You can now do this:

```julia
features, labels = load_data("iris")
model1 = build_forest(labels, features, 2, 150) # n_trees = 150
model = build_forest(model1, labels, features, 2, 50) # add 50 trees
```

New docstring below.

<details>

    build_forest(model, labels, features, options...; keyword_options...)

Return an updated version of `model` with additional `n_trees=options[2]` added to the
forest. Here `options` and `keyword_options` are as for the regular `build_forest` method,
which excludes the `model` argument.

Even if training data is the same in all `build_forest` calls, it is not practically
possible to guarantee adding trees in steps is identical to adding them all at once,
because of the way random number generators are generated and used. But in all other
respects these approaches are equivalent.

# Example

```
features, labels = load_data("iris")
features = float.(features)
labels = string.(labels)
```

The call

```
model = build_forest(labels, features, 2, 200) # n_trees = 200
```

is approximately equivalent to

```
model1 = build_forest(labels, features, 2, 150) # n_trees = 150
model = build_forest(model1, labels, features, 2, 50) # n_trees = 50
```
</details>
