### PR TITLE
Apply JuliaFormatter

### DIFF
--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -5,7 +5,7 @@ using DelimitedFiles
 using LinearAlgebra
 using Random
 using Statistics
-using AbstractTrees: AbstractTrees
+import AbstractTrees
 
 export Leaf,
     Node,

--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -5,21 +5,46 @@ using DelimitedFiles
 using LinearAlgebra
 using Random
 using Statistics
-import AbstractTrees
+using AbstractTrees: AbstractTrees
 
-export Leaf, Node, Root, Ensemble, print_tree, depth, build_stump, build_tree,
-       prune_tree, apply_tree, apply_tree_proba, nfoldCV_tree, build_forest,
-       apply_forest, apply_forest_proba, nfoldCV_forest, build_adaboost_stumps,
-       apply_adaboost_stumps, apply_adaboost_stumps_proba, nfoldCV_stumps,
-       load_data, impurity_importance, split_importance, permutation_importance
+export Leaf,
+    Node,
+    Root,
+    Ensemble,
+    print_tree,
+    depth,
+    build_stump,
+    build_tree,
+    prune_tree,
+    apply_tree,
+    apply_tree_proba,
+    nfoldCV_tree,
+    build_forest,
+    apply_forest,
+    apply_forest_proba,
+    nfoldCV_forest,
+    build_adaboost_stumps,
+    apply_adaboost_stumps,
+    apply_adaboost_stumps_proba,
+    nfoldCV_stumps,
+    load_data,
+    impurity_importance,
+    split_importance,
+    permutation_importance
 
 # ScikitLearn API
-export DecisionTreeClassifier, DecisionTreeRegressor, RandomForestClassifier,
-       RandomForestRegressor, AdaBoostStumpClassifier,
-       # Should we export these functions? They have a conflict with
-       # DataFrames/RDataset over fit!, and users can always
-       # `using ScikitLearnBase`.
-       predict, predict_proba, fit!, get_classes
+export DecisionTreeClassifier,
+    DecisionTreeRegressor,
+    RandomForestClassifier,
+    RandomForestRegressor,
+    AdaBoostStumpClassifier,
+    # Should we export these functions? They have a conflict with
+    # DataFrames/RDataset over fit!, and users can always
+    # `using ScikitLearnBase`.
+    predict,
+    predict_proba,
+    fit!,
+    get_classes
 
 export InfoNode, InfoLeaf, wrap
 
@@ -27,29 +52,29 @@ export InfoNode, InfoLeaf, wrap
 ########## Types ##########
 
 struct Leaf{T}
-    majority :: T
-    values   :: Vector{T}
+    majority::T
+    values::Vector{T}
 end
 
-struct Node{S, T}
-    featid  :: Int
-    featval :: S
-    left    :: Union{Leaf{T}, Node{S, T}}
-    right   :: Union{Leaf{T}, Node{S, T}}
+struct Node{S,T}
+    featid::Int
+    featval::S
+    left::Union{Leaf{T},Node{S,T}}
+    right::Union{Leaf{T},Node{S,T}}
 end
 
-const LeafOrNode{S, T} = Union{Leaf{T}, Node{S, T}}
+const LeafOrNode{S,T} = Union{Leaf{T},Node{S,T}}
 
-struct Root{S, T}
-    node    :: LeafOrNode{S, T}
-    n_feat  :: Int
-    featim  :: Vector{Float64}   # impurity importance
+struct Root{S,T}
+    node::LeafOrNode{S,T}
+    n_feat::Int
+    featim::Vector{Float64}   # impurity importance
 end
 
-struct Ensemble{S, T}
-    trees   :: Vector{LeafOrNode{S, T}}
-    n_feat  :: Int
-    featim  :: Vector{Float64}
+struct Ensemble{S,T}
+    trees::Vector{LeafOrNode{S,T}}
+    n_feat::Int
+    featim::Vector{Float64}
 end
 
 is_leaf(l::Leaf) = true
@@ -57,29 +82,30 @@ is_leaf(n::Node) = false
 
 _zero(::Type{String}) = ""
 _zero(x::Any) = zero(x)
-convert(::Type{Node{S, T}}, lf::Leaf{T}) where {S, T} =
+function convert(::Type{Node{S,T}}, lf::Leaf{T}) where {S,T}
     Node(0, _zero(S), lf, Leaf(_zero(T), [_zero(T)]))
-convert(::Type{Root{S, T}}, node::LeafOrNode{S, T}) where {S, T} =
-    Root{S, T}(node, 0, Float64[])
-convert(::Type{LeafOrNode{S, T}}, tree::Root{S, T}) where {S, T} = tree.node
-promote_rule(::Type{Node{S, T}}, ::Type{Leaf{T}}) where {S, T} = Node{S, T}
-promote_rule(::Type{Leaf{T}}, ::Type{Node{S, T}}) where {S, T} = Node{S, T}
-promote_rule(::Type{Root{S, T}}, ::Type{Leaf{T}}) where {S, T} = Root{S, T}
-promote_rule(::Type{Leaf{T}}, ::Type{Root{S, T}}) where {S, T} = Root{S, T}
-promote_rule(::Type{Root{S, T}}, ::Type{Node{S, T}}) where {S, T} = Root{S, T}
-promote_rule(::Type{Node{S, T}}, ::Type{Root{S, T}}) where {S, T} = Root{S, T}
+end
+function convert(::Type{Root{S,T}}, node::LeafOrNode{S,T}) where {S,T}
+    Root{S,T}(node, 0, Float64[])
+end
+convert(::Type{LeafOrNode{S,T}}, tree::Root{S,T}) where {S,T} = tree.node
+promote_rule(::Type{Node{S,T}}, ::Type{Leaf{T}}) where {S,T} = Node{S,T}
+promote_rule(::Type{Leaf{T}}, ::Type{Node{S,T}}) where {S,T} = Node{S,T}
+promote_rule(::Type{Root{S,T}}, ::Type{Leaf{T}}) where {S,T} = Root{S,T}
+promote_rule(::Type{Leaf{T}}, ::Type{Root{S,T}}) where {S,T} = Root{S,T}
+promote_rule(::Type{Root{S,T}}, ::Type{Node{S,T}}) where {S,T} = Root{S,T}
+promote_rule(::Type{Node{S,T}}, ::Type{Root{S,T}}) where {S,T} = Root{S,T}
 
 const DOC_WHATS_A_TREE =
-    "Here `tree` is any `DecisionTree.Root`, `DecisionTree.Node` or "*
+    "Here `tree` is any `DecisionTree.Root`, `DecisionTree.Node` or " *
     "`DecisionTree.Leaf` instance, as returned, for example, by [`build_tree`](@ref)."
 const DOC_WHATS_A_FOREST =
-    "Here `forest` is any `DecisionTree.Ensemble` instance, as returned, for "*
+    "Here `forest` is any `DecisionTree.Ensemble` instance, as returned, for " *
     "example, by [`build_forest`](@ref)."
-const DOC_ENSEMBLE =
-    "`DecisionTree.Ensemble` objects are returned by, for example, `build_forest`."
+const DOC_ENSEMBLE = "`DecisionTree.Ensemble` objects are returned by, for example, `build_forest`."
 const ERR_ENSEMBLE_VCAT = DimensionMismatch(
-    "Ensembles that record feature impurity importances cannot be combined when "*
-        "they were generated using differing numbers of features. "
+    "Ensembles that record feature impurity importances cannot be combined when " *
+    "they were generated using differing numbers of features. ",
 )
 
 """
@@ -124,12 +150,13 @@ function Base.vcat(e1::Ensemble{S,T}, e2::Ensemble{S,T}) where {S,T}
     Ensemble{S,T}(trees, e2.n_feat, featim)
 end
 
-Base.getindex(ensemble::DecisionTree.Ensemble, I) =
+function Base.getindex(ensemble::DecisionTree.Ensemble, I)
     DecisionTree.Ensemble(ensemble.trees[I], ensemble.n_feat, ensemble.featim)
+end
 
 # make a Random Number Generator object
 mk_rng(rng::Random.AbstractRNG) = rng
-mk_rng(seed::T) where T <: Integer = Random.MersenneTwister(seed)
+mk_rng(seed::T) where {T<:Integer} = Random.MersenneTwister(seed)
 
 ##############################
 ########## Includes ##########
@@ -141,7 +168,6 @@ include("classification/main.jl")
 include("regression/main.jl")
 include("scikitlearnAPI.jl")
 include("abstract_trees.jl")
-
 
 #############################
 ########## Methods ##########
@@ -155,7 +181,9 @@ depth(leaf::Leaf) = 0
 depth(tree::Node) = 1 + max(depth(tree.left), depth(tree.right))
 depth(tree::Root) = depth(tree.node)
 
-function print_tree(io::IO, leaf::Leaf, depth=-1, indent=0; sigdigits=4, feature_names=nothing)
+function print_tree(
+    io::IO, leaf::Leaf, depth=-1, indent=0; sigdigits=4, feature_names=nothing
+)
     n_matches = count(leaf.values .== leaf.majority)
     ratio = string(n_matches, "/", length(leaf.values))
     println(io, "$(leaf.majority) : $(ratio)")
@@ -164,8 +192,9 @@ function print_tree(leaf::Leaf, depth=-1, indent=0; sigdigits=4, feature_names=n
     return print_tree(stdout, leaf, depth, indent; sigdigits, feature_names)
 end
 
-
-function print_tree(io::IO, tree::Root, depth=-1, indent=0; sigdigits=4, feature_names=nothing)
+function print_tree(
+    io::IO, tree::Root, depth=-1, indent=0; sigdigits=4, feature_names=nothing
+)
     return print_tree(io, tree.node, depth, indent; sigdigits, feature_names)
 end
 function print_tree(tree::Root, depth=-1, indent=0; sigdigits=4, feature_names=nothing)
@@ -199,20 +228,24 @@ To facilitate visualisation of trees using third party packages, a `DecisionTree
 `DecisionTree.Node` object or  `DecisionTree.Root` object can be wrapped to obtain a tree structure implementing the
 AbstractTrees.jl interface. See  [`wrap`](@ref)` for details.
 """
-function print_tree(io::IO, tree::Node, depth=-1, indent=0; sigdigits=2, feature_names=nothing)
+function print_tree(
+    io::IO, tree::Node, depth=-1, indent=0; sigdigits=2, feature_names=nothing
+)
     if depth == indent
         println(io)
-        return
+        return nothing
     end
     featval = round(tree.featval; sigdigits)
     if feature_names === nothing
         println(io, "Feature $(tree.featid) < $featval ?")
     else
-        println(io, "Feature $(tree.featid): \"$(feature_names[tree.featid])\" < $featval ?")
+        println(
+            io, "Feature $(tree.featid): \"$(feature_names[tree.featid])\" < $featval ?"
+        )
     end
-    print(io, "    " ^ indent * "├─ ")
+    print(io, "    "^indent * "├─ ")
     print_tree(io, tree.left, depth, indent + 1; sigdigits, feature_names)
-    print(io, "    " ^ indent * "└─ ")
+    print(io, "    "^indent * "└─ ")
     print_tree(io, tree.right, depth, indent + 1; sigdigits, feature_names)
 end
 function print_tree(tree::Node, depth=-1, indent=0; sigdigits=4, feature_names=nothing)
@@ -222,26 +255,26 @@ end
 function show(io::IO, leaf::Leaf)
     println(io, "Decision Leaf")
     println(io, "Majority: $(leaf.majority)")
-    print(io,   "Samples:  $(length(leaf.values))")
+    print(io, "Samples:  $(length(leaf.values))")
 end
 
 function show(io::IO, tree::Node)
     println(io, "Decision Tree")
     println(io, "Leaves: $(length(tree))")
-    print(io,   "Depth:  $(depth(tree))")
+    print(io, "Depth:  $(depth(tree))")
 end
 
 function show(io::IO, tree::Root)
     println(io, "Decision Tree")
     println(io, "Leaves: $(length(tree))")
-    print(io,   "Depth:  $(depth(tree))")
+    print(io, "Depth:  $(depth(tree))")
 end
 
 function show(io::IO, ensemble::Ensemble)
     println(io, "Ensemble of Decision Trees")
     println(io, "Trees:      $(length(ensemble))")
     println(io, "Avg Leaves: $(mean([length(tree) for tree in ensemble.trees]))")
-    print(io,   "Avg Depth:  $(mean([depth(tree) for tree in ensemble.trees]))")
+    print(io, "Avg Depth:  $(mean([depth(tree) for tree in ensemble.trees]))")
 end
 
 end # module

--- a/src/classification/main.jl
+++ b/src/classification/main.jl
@@ -512,7 +512,7 @@ function build_forest(
                 min_samples_split,
                 min_purity_increase;
                 loss,
-                impurity_importance=impurity_importance,
+                impurity_importance,
             )
         end
     end

--- a/src/classification/main.jl
+++ b/src/classification/main.jl
@@ -33,33 +33,28 @@ function stack_function_results(row_fun::Function, X::AbstractMatrix)
     return out
 end
 
-
 function _convert(
-        node   :: treeclassifier.NodeMeta{S},
-        list   :: AbstractVector{T},
-        labels :: AbstractVector{T}
-    ) where {S, T}
-
+    node::treeclassifier.NodeMeta{S}, list::AbstractVector{T}, labels::AbstractVector{T}
+) where {S,T}
     if node.is_leaf
         return Leaf{T}(list[node.label], labels[node.region])
     else
         left = _convert(node.l, list, labels)
         right = _convert(node.r, list, labels)
-        return Node{S, T}(node.feature, node.threshold, left, right)
+        return Node{S,T}(node.feature, node.threshold, left, right)
     end
 end
 
 function update_using_impurity!(
-    feature_importance::Vector{Float64},
-    node::treeclassifier.NodeMeta{S}
-) where S
+    feature_importance::Vector{Float64}, node::treeclassifier.NodeMeta{S}
+) where {S}
     if !node.is_leaf
         update_using_impurity!(feature_importance, node.l)
         update_using_impurity!(feature_importance, node.r)
         feature_importance[node.feature] +=
             node.node_impurity - node.l.node_impurity - node.r.node_impurity
     end
-    return
+    return nothing
 end
 
 nsample(leaf::Leaf) = length(leaf.values)
@@ -77,11 +72,11 @@ function votes_distribution(labels)
 end
 
 function update_pruned_impurity!(
-    tree::LeafOrNode{S, T},
+    tree::LeafOrNode{S,T},
     feature_importance::Vector{Float64},
     ntt::Int,
-    loss::Function = util.entropy
-) where {S, T}
+    loss::Function=util.entropy,
+) where {S,T}
     all_labels = [tree.left.values; tree.right.values]
     nc = votes_distribution(all_labels)
     nt = length(all_labels)
@@ -94,57 +89,63 @@ function update_pruned_impurity!(
 end
 
 function update_pruned_impurity!(
-    tree::LeafOrNode{S, T},
+    tree::LeafOrNode{S,T},
     feature_importance::Vector{Float64},
     ntt::Int,
-    loss::Function = mean_squared_error
-) where {S, T <: Float64}
+    loss::Function=mean_squared_error,
+) where {S,T<:Float64}
     μl = mean(tree.left.values)
     nl = length(tree.left.values)
     μr = mean(tree.right.values)
     nr = length(tree.right.values)
     nt = nl + nr
     μt = (nl * μl + nr * μr) / nt
-    feature_importance[tree.featid] -= (nt * loss([tree.left.values; tree.right.values], repeat([μt], nt)) - nl * loss(tree.left.values, repeat([μl], nl)) - nr * loss(tree.right.values, repeat([μr], nr))) / ntt
+    feature_importance[tree.featid] -=
+        (
+            nt * loss([tree.left.values; tree.right.values], repeat([μt], nt)) -
+            nl * loss(tree.left.values, repeat([μl], nl)) -
+            nr * loss(tree.right.values, repeat([μr], nr))
+        ) / ntt
 end
 
 ################################################################################
 
 function build_stump(
-        labels              :: AbstractVector{T},
-        features            :: AbstractMatrix{S},
-        weights              = nothing;
-        rng                  = Random.GLOBAL_RNG,
-        impurity_importance :: Bool = true) where {S, T}
-
+    labels::AbstractVector{T},
+    features::AbstractMatrix{S},
+    weights=nothing;
+    rng=Random.GLOBAL_RNG,
+    impurity_importance::Bool=true,
+) where {S,T}
     rng = mk_rng(rng)::Random.AbstractRNG
-    t = treeclassifier.fit(
-        X                   = features,
-        Y                   = labels,
-        W                   = weights,
-        loss                = treeclassifier.util.zero_one,
-        max_features        = size(features, 2),
-        max_depth           = 1,
-        min_samples_leaf    = 1,
-        min_samples_split   = 2,
-        min_purity_increase = 0.0;
-        rng                 = rng)
+    t = treeclassifier.fit(;
+        X=features,
+        Y=labels,
+        W=weights,
+        loss=treeclassifier.util.zero_one,
+        max_features=size(features, 2),
+        max_depth=1,
+        min_samples_leaf=1,
+        min_samples_split=2,
+        min_purity_increase=0.0,
+        rng,
+    )
 
     return _build_tree(t, labels, size(features, 2), size(features, 1), impurity_importance)
 end
 
 function build_tree(
-        labels              :: AbstractVector{T},
-        features            :: AbstractMatrix{S},
-        n_subfeatures        = 0,
-        max_depth            = -1,
-        min_samples_leaf     = 1,
-        min_samples_split    = 2,
-        min_purity_increase  = 0.0;
-        loss                 = util.entropy :: Function,
-        rng                  = Random.GLOBAL_RNG,
-        impurity_importance :: Bool = true) where {S, T}
-
+    labels::AbstractVector{T},
+    features::AbstractMatrix{S},
+    n_subfeatures=0,
+    max_depth=-1,
+    min_samples_leaf=1,
+    min_samples_split=2,
+    min_purity_increase=0.0;
+    loss=util.entropy::Function,
+    rng=Random.GLOBAL_RNG,
+    impurity_importance::Bool=true,
+) where {S,T}
     if max_depth == -1
         max_depth = typemax(Int)
     end
@@ -153,35 +154,36 @@ function build_tree(
     end
 
     rng = mk_rng(rng)::Random.AbstractRNG
-    t = treeclassifier.fit(
-        X                   = features,
-        Y                   = labels,
-        W                   = nothing,
-        loss                = loss,
-        max_features        = Int(n_subfeatures),
-        max_depth           = Int(max_depth),
-        min_samples_leaf    = Int(min_samples_leaf),
-        min_samples_split   = Int(min_samples_split),
-        min_purity_increase = Float64(min_purity_increase),
-        rng                 = rng)
+    t = treeclassifier.fit(;
+        X=features,
+        Y=labels,
+        W=nothing,
+        loss,
+        max_features=Int(n_subfeatures),
+        max_depth=Int(max_depth),
+        min_samples_leaf=Int(min_samples_leaf),
+        min_samples_split=Int(min_samples_split),
+        min_purity_increase=Float64(min_purity_increase),
+        rng,
+    )
 
     return _build_tree(t, labels, size(features, 2), size(features, 1), impurity_importance)
 end
 
 function _build_tree(
-    tree::treeclassifier.Tree{S, T},
+    tree::treeclassifier.Tree{S,T},
     labels::AbstractVector{T},
     n_features,
     n_samples,
-    impurity_importance::Bool
-) where {S, T}
+    impurity_importance::Bool,
+) where {S,T}
     node = _convert(tree.root, tree.list, labels[tree.labels])
     if !impurity_importance
-        return Root{S, T}(node, n_features, Float64[])
+        return Root{S,T}(node, n_features, Float64[])
     else
         fi = zeros(Float64, n_features)
         update_using_impurity!(fi, tree.root)
-        return Root{S, T}(node, n_features, fi ./ n_samples)
+        return Root{S,T}(node, n_features, fi ./ n_samples)
     end
 end
 
@@ -216,19 +218,17 @@ See also [`build_tree`](@ref).
 
 """
 function prune_tree(
-    tree::Union{Root{S, T}, LeafOrNode{S, T}},
+    tree::Union{Root{S,T},LeafOrNode{S,T}},
     purity_thresh=1.0,
-    loss::Function = T <: Float64 ? mean_squared_error : util.entropy
-) where {S, T}
+    loss::Function=T <: Float64 ? mean_squared_error : util.entropy,
+) where {S,T}
     if purity_thresh >= 1.0
         return tree
     end
     ntt = nsample(tree)
     function _prune_run_stump(
-        tree::LeafOrNode{S, T},
-        purity_thresh::Real,
-        fi::Vector{Float64} = Float64[]
-    ) where {S, T}
+        tree::LeafOrNode{S,T}, purity_thresh::Real, fi::Vector{Float64}=Float64[]
+    ) where {S,T}
         all_labels = [tree.left.values; tree.right.values]
         majority = majority_vote(all_labels)
         matches = findall(all_labels .== majority)
@@ -242,16 +242,14 @@ function prune_tree(
             return tree
         end
     end
-    function _prune_run(tree::Root{S, T}, purity_thresh::Real) where {S, T}
+    function _prune_run(tree::Root{S,T}, purity_thresh::Real) where {S,T}
         fi = deepcopy(tree.featim) ## recalculate feature importances
         node = _prune_run(tree.node, purity_thresh, fi)
-        return Root{S, T}(node, tree.n_feat, fi)
+        return Root{S,T}(node, tree.n_feat, fi)
     end
     function _prune_run(
-        tree::LeafOrNode{S, T},
-        purity_thresh::Real,
-        fi::Vector{Float64} = Float64[]
-    ) where {S, T}
+        tree::LeafOrNode{S,T}, purity_thresh::Real, fi::Vector{Float64}=Float64[]
+    ) where {S,T}
         N = length(tree)
         if N == 1        ## a Leaf
             return tree
@@ -260,7 +258,7 @@ function prune_tree(
         else
             left = _prune_run(tree.left, purity_thresh, fi)
             right = _prune_run(tree.right, purity_thresh, fi)
-            return Node{S, T}(tree.featid, tree.featval, left, right)
+            return Node{S,T}(tree.featid, tree.featval, left, right)
         end
     end
     pruned = _prune_run(tree, purity_thresh)
@@ -271,15 +269,12 @@ function prune_tree(
     return pruned
 end
 
-
-
 apply_tree(leaf::Leaf, feature::AbstractVector) = leaf.majority
-apply_tree(
-    tree::Root{S, T},
-    features::AbstractVector{S}
-) where {S, T} = apply_tree(tree.node, features)
+function apply_tree(tree::Root{S,T}, features::AbstractVector{S}) where {S,T}
+    apply_tree(tree.node, features)
+end
 
-function apply_tree(tree::Node{S, T}, features::AbstractVector{S}) where {S, T}
+function apply_tree(tree::Node{S,T}, features::AbstractVector{S}) where {S,T}
     if tree.featid == 0
         return apply_tree(tree.left, features)
     elseif features[tree.featid] < tree.featval
@@ -289,12 +284,11 @@ function apply_tree(tree::Node{S, T}, features::AbstractVector{S}) where {S, T}
     end
 end
 
-apply_tree(
-    tree::Root{S, T},
-    features::AbstractMatrix{S}
-) where {S, T} = apply_tree(tree.node, features)
-function apply_tree(tree::LeafOrNode{S, T}, features::AbstractMatrix{S}) where {S, T}
-    N = size(features,1)
+function apply_tree(tree::Root{S,T}, features::AbstractMatrix{S}) where {S,T}
+    apply_tree(tree.node, features)
+end
+function apply_tree(tree::LeafOrNode{S,T}, features::AbstractMatrix{S}) where {S,T}
+    N = size(features, 1)
     predictions = Array{T}(undef, N)
     for i in 1:N
         predictions[i] = apply_tree(tree, features[i, :])
@@ -318,16 +312,14 @@ an `N_row` x `n_labels` matrix of probabilities, each row summing to one. $DOC_W
 See also [`build_tree`](@ref).
 
 """
-apply_tree_proba(tree::Root{S, T}, features::AbstractVector{S}, labels) where {S, T} =
+function apply_tree_proba(tree::Root{S,T}, features::AbstractVector{S}, labels) where {S,T}
     apply_tree_proba(tree.node, features, labels)
-apply_tree_proba(leaf::Leaf{T}, features::AbstractVector{S}, labels) where {S, T} =
+end
+function apply_tree_proba(leaf::Leaf{T}, features::AbstractVector{S}, labels) where {S,T}
     compute_probabilities(labels, leaf.values)
+end
 
-function apply_tree_proba(
-    tree::Node{S, T},
-    features::AbstractVector{S},
-    labels
-) where {S, T}
+function apply_tree_proba(tree::Node{S,T}, features::AbstractVector{S}, labels) where {S,T}
     if tree.featval === nothing
         return apply_tree_proba(tree.left, features, labels)
     elseif features[tree.featid] < tree.featval
@@ -336,10 +328,14 @@ function apply_tree_proba(
         return apply_tree_proba(tree.right, features, labels)
     end
 end
-apply_tree_proba(tree::Root{S, T}, features::AbstractMatrix{S}, labels) where {S, T} =
+function apply_tree_proba(tree::Root{S,T}, features::AbstractMatrix{S}, labels) where {S,T}
     apply_tree_proba(tree.node, features, labels)
-apply_tree_proba(tree::LeafOrNode{S, T}, features::AbstractMatrix{S}, labels) where {S, T} =
-    stack_function_results(row->apply_tree_proba(tree, row, labels), features)
+end
+function apply_tree_proba(
+    tree::LeafOrNode{S,T}, features::AbstractMatrix{S}, labels
+) where {S,T}
+    stack_function_results(row -> apply_tree_proba(tree, row, labels), features)
+end
 
 """
     build_forest(labels, features, options...; keyword_options...)
@@ -448,18 +444,18 @@ See also [`build_tree`](@ref), [`apply_forest`](@ref), [`apply_forest_proba`](@r
 
 """
 function build_forest(
-        labels              :: AbstractVector{T},
-        features            :: AbstractMatrix{S},
-        n_subfeatures       = -1,
-        n_trees             = 10,
-        partial_sampling    = 0.7,
-        max_depth           = -1,
-        min_samples_leaf    = 1,
-        min_samples_split   = 2,
-        min_purity_increase = 0.0;
-        rng::Union{Integer,AbstractRNG} = Random.GLOBAL_RNG,
-        impurity_importance :: Bool = true) where {S, T}
-
+    labels::AbstractVector{T},
+    features::AbstractMatrix{S},
+    n_subfeatures=-1,
+    n_trees=10,
+    partial_sampling=0.7,
+    max_depth=-1,
+    min_samples_leaf=1,
+    min_samples_split=2,
+    min_purity_increase=0.0;
+    rng::Union{Integer,AbstractRNG}=Random.GLOBAL_RNG,
+    impurity_importance::Bool=true,
+) where {S,T}
     if n_trees < 1
         throw("the number of trees must be >= 1")
     end
@@ -475,9 +471,11 @@ function build_forest(
     t_samples = length(labels)
     n_samples = floor(Int, partial_sampling * t_samples)
 
-    forest = impurity_importance ?
-        Vector{Root{S, T}}(undef, n_trees) :
-        Vector{LeafOrNode{S, T}}(undef, n_trees)
+    forest = if impurity_importance
+        Vector{Root{S,T}}(undef, n_trees)
+    else
+        Vector{LeafOrNode{S,T}}(undef, n_trees)
+    end
 
     entropy_terms = util.compute_entropy_terms(n_samples)
     loss = (ns, n) -> util.entropy(ns, n, entropy_terms)
@@ -490,15 +488,16 @@ function build_forest(
             inds = rand(_rng, 1:t_samples, n_samples)
             forest[i] = build_tree(
                 labels[inds],
-                features[inds,:],
+                features[inds, :],
                 n_subfeatures,
                 max_depth,
                 min_samples_leaf,
                 min_samples_split,
-                min_purity_increase,
-                loss = loss,
-                rng = _rng,
-                impurity_importance = impurity_importance)
+                min_purity_increase;
+                loss,
+                rng=_rng,
+                impurity_importance,
+            )
         end
     else # each thread gets its own seeded rng
         Threads.@threads for i in 1:n_trees
@@ -506,14 +505,15 @@ function build_forest(
             inds = rand(1:t_samples, n_samples)
             forest[i] = build_tree(
                 labels[inds],
-                features[inds,:],
+                features[inds, :],
                 n_subfeatures,
                 max_depth,
                 min_samples_leaf,
                 min_samples_split,
-                min_purity_increase,
-                loss = loss,
-                impurity_importance = impurity_importance)
+                min_purity_increase;
+                loss,
+                impurity_importance=impurity_importance,
+            )
         end
     end
 
@@ -521,9 +521,9 @@ function build_forest(
 end
 
 const ERR_CANT_UPDATE_IMPURITY_IMPORTANCE = DimensionMismatch(
-    "Looks like you want to add trees to a model previously trained using a "*
-        "different number of features, which means impurity importances "*
-        "cannot be updated. Fix by setting `impurity_importance=false`. "
+    "Looks like you want to add trees to a model previously trained using a " *
+    "different number of features, which means impurity importances " *
+    "cannot be updated. Fix by setting `impurity_importance=false`. ",
 )
 
 """
@@ -561,13 +561,13 @@ model = build_forest(model1, labels, features, 2, 50) # n_trees = 50
 
 """
 function build_forest(
-    model               :: Ensemble{S,T},
-    labels              :: AbstractVector{T},
-    features            :: AbstractMatrix{S},
+    model::Ensemble{S,T},
+    labels::AbstractVector{T},
+    features::AbstractMatrix{S},
     options...;
     impurity_importance=true,
     kwoptions...,
-    ) where {S, T}
+) where {S,T}
 
     # Only compute impurity importances if requested and present in the existing ensemble:
     impurity_importance = impurity_importance && has_impurity_importance(model)
@@ -580,28 +580,25 @@ function build_forest(
         throw(ERR_CANT_UPDATE_IMPURITY_IMPORTANCE)
     end
     new_forest = build_forest(
-        labels,
-        features,
-        options...;
-        impurity_importance,
-        kwoptions...)
+        labels, features, options...; impurity_importance, kwoptions...
+    )
 
     # `model` and `new_forest` are both `Ensemble` objects:
     return vcat(model, new_forest)
 end
 
 function _build_forest(
-        forest              :: Vector{<:Union{Root{S,T},LeafOrNode{S,T}}},
-        n_features          ,
-        n_trees             ,
-        impurity_importance :: Bool) where {S,T}
-
+    forest::Vector{<:Union{Root{S,T},LeafOrNode{S,T}}},
+    n_features,
+    n_trees,
+    impurity_importance::Bool,
+) where {S,T}
     normalized_importance = if !impurity_importance
         Float64[]
     else
         fi = zeros(Float64, n_features)
         for tree in forest
-            ti = DecisionTree.impurity_importance(tree, normalize = true)
+            ti = DecisionTree.impurity_importance(tree; normalize=true)
             if !isempty(ti)
                 fi .+= ti
             end
@@ -615,7 +612,7 @@ function _build_forest(
     return Ensemble{S,T}(forest, n_features, normalized_importance)
 end
 
-function apply_forest(forest::Ensemble{S, T}, features::AbstractVector{S}) where {S, T}
+function apply_forest(forest::Ensemble{S,T}, features::AbstractVector{S}) where {S,T}
     n_trees = length(forest)
     votes = Array{T}(undef, n_trees)
     for i in 1:n_trees
@@ -639,11 +636,9 @@ Apply learned model `forest` to `features`. $DOC_WHATS_A_FOREST
 - `use_multithreading::Bool`: `true` to use multiple cores, if available. `false` by default.
 """
 function apply_forest(
-        forest::Ensemble{S, T},
-        features::AbstractMatrix{S};
-        use_multithreading = false
-    ) where {S, T}
-    N = size(features,1)
+    forest::Ensemble{S,T}, features::AbstractMatrix{S}; use_multithreading=false
+) where {S,T}
+    N = size(features, 1)
     predictions = Array{T}(undef, N)
     if use_multithreading
         Threads.@threads for i in 1:N
@@ -671,42 +666,35 @@ See also [`build_forest`](@ref).
 
 """
 function apply_forest_proba(
-    forest::Ensemble{S, T},
-    features::AbstractVector{S},
-    labels
-) where {S, T}
+    forest::Ensemble{S,T}, features::AbstractVector{S}, labels
+) where {S,T}
     votes = [apply_tree(tree, features) for tree in forest.trees]
     return compute_probabilities(labels, votes)
 end
 
-apply_forest_proba(
-    forest::Ensemble{S, T},
-    features::AbstractMatrix{S},
-    labels
-) where {S, T} =
-    stack_function_results(row->apply_forest_proba(forest, row, labels),
-                           features)
+function apply_forest_proba(
+    forest::Ensemble{S,T}, features::AbstractMatrix{S}, labels
+) where {S,T}
+    stack_function_results(row -> apply_forest_proba(forest, row, labels), features)
+end
 
 function build_adaboost_stumps(
-        labels              :: AbstractVector{T},
-        features            :: AbstractMatrix{S},
-        n_iterations        :: Integer;
-        rng                  = Random.GLOBAL_RNG) where {S, T}
+    labels::AbstractVector{T},
+    features::AbstractMatrix{S},
+    n_iterations::Integer;
+    rng=Random.GLOBAL_RNG,
+) where {S,T}
     N = length(labels)
     n_labels = length(unique(labels))
     base_coeff = log(n_labels - 1)
     thresh = 1 - 1 / n_labels
     weights = ones(N) / N
-    stumps = Node{S, T}[]
+    stumps = Node{S,T}[]
     coeffs = Float64[]
     n_features = size(features, 2)
     for i in 1:n_iterations
         new_stump = build_stump(
-            labels,
-            features,
-            weights;
-            rng=mk_rng(rng),
-            impurity_importance=false
+            labels, features, weights; rng=mk_rng(rng), impurity_importance=false
         )
         predictions = apply_tree(new_stump, features)
         err = _weighted_error(labels, predictions, weights)
@@ -724,19 +712,18 @@ function build_adaboost_stumps(
             break
         end
     end
-    return (Ensemble{S, T}(stumps, n_features, Float64[]), coeffs)
+    return (Ensemble{S,T}(stumps, n_features, Float64[]), coeffs)
 end
 
-apply_adaboost_stumps(
-    trees::Tuple{<: Ensemble{S, T}, AbstractVector{Float64}},
-    features::AbstractVecOrMat{S}
-) where {S, T} = apply_adaboost_stumps(trees..., features)
+function apply_adaboost_stumps(
+    trees::Tuple{<:Ensemble{S,T},AbstractVector{Float64}}, features::AbstractVecOrMat{S}
+) where {S,T}
+    apply_adaboost_stumps(trees..., features)
+end
 
 function apply_adaboost_stumps(
-    stumps::Ensemble{S, T},
-    coeffs::AbstractVector{Float64},
-    features::AbstractVector{S}
-) where {S, T}
+    stumps::Ensemble{S,T}, coeffs::AbstractVector{Float64}, features::AbstractVector{S}
+) where {S,T}
     n_stumps = length(stumps)
     counts = Dict()
     for i in 1:n_stumps
@@ -745,7 +732,7 @@ function apply_adaboost_stumps(
     end
     top_prediction = stumps.trees[1].left.majority
     top_count = -Inf
-    for (k,v) in counts
+    for (k, v) in counts
         if v > top_count
             top_prediction = k
             top_count = v
@@ -755,14 +742,12 @@ function apply_adaboost_stumps(
 end
 
 function apply_adaboost_stumps(
-    stumps::Ensemble{S, T},
-    coeffs::AbstractVector{Float64},
-    features::AbstractMatrix{S}
-) where {S, T}
+    stumps::Ensemble{S,T}, coeffs::AbstractVector{Float64}, features::AbstractMatrix{S}
+) where {S,T}
     n_samples = size(features, 1)
     predictions = Array{T}(undef, n_samples)
     for i in 1:n_samples
-        predictions[i] = apply_adaboost_stumps(stumps, coeffs, features[i,:])
+        predictions[i] = apply_adaboost_stumps(stumps, coeffs, features[i, :])
     end
     return predictions
 end
@@ -780,23 +765,22 @@ See also [`build_adaboost_stumps`](@ref).
 
 """
 function apply_adaboost_stumps_proba(
-    stumps::Ensemble{S, T},
+    stumps::Ensemble{S,T},
     coeffs::AbstractVector{Float64},
     features::AbstractVector{S},
-    labels::AbstractVector{T}
-) where {S, T}
+    labels::AbstractVector{T},
+) where {S,T}
     votes = [apply_tree(stump, features) for stump in stumps.trees]
     compute_probabilities(labels, votes, coeffs)
 end
 
 function apply_adaboost_stumps_proba(
-    stumps::Ensemble{S, T},
+    stumps::Ensemble{S,T},
     coeffs::AbstractVector{Float64},
     features::AbstractMatrix{S},
-    labels::AbstractVector{T}
-) where {S, T}
+    labels::AbstractVector{T},
+) where {S,T}
     stack_function_results(
-        row->apply_adaboost_stumps_proba(stumps, coeffs, row, labels),
-        features
+        row -> apply_adaboost_stumps_proba(stumps, coeffs, row, labels), features
     )
 end

--- a/src/load_data.jl
+++ b/src/load_data.jl
@@ -5,9 +5,7 @@ function load_data(name)
     if name == "digits"
         f = open(joinpath(data_path, "digits.csv"))
         data = readlines(f)[2:end]
-        data = [[parse(Float32, i)
-            for i in split(row, ",")]
-            for row in data]
+        data = [[parse(Float32, i) for i in split(row, ",")] for row in data]
         data = hcat(data...)
         Y = Int.(data[1, 1:end]) .+ 1
         X = convert(Matrix, transpose(data[2:end, 1:end]))
@@ -22,9 +20,9 @@ function load_data(name)
     end
 
     if name == "adult"
-        adult = DelimitedFiles.readdlm(joinpath(data_path, "adult.csv"), ',');
-        X = adult[:, 1:14];
-        Y = adult[:, 15];
+        adult = DelimitedFiles.readdlm(joinpath(data_path, "adult.csv"), ',')
+        X = adult[:, 1:14]
+        Y = adult[:, 15]
         return X, Y
     end
 

--- a/src/regression/main.jl
+++ b/src/regression/main.jl
@@ -1,39 +1,47 @@
 include("tree.jl")
 
-function _convert(node::treeregressor.NodeMeta{S}, labels::Array{T}) where {S, T <: Float64}
+function _convert(node::treeregressor.NodeMeta{S}, labels::Array{T}) where {S,T<:Float64}
     if node.is_leaf
         return Leaf{T}(node.label, labels[node.region])
     else
         left = _convert(node.l, labels)
         right = _convert(node.r, labels)
-        return Node{S, T}(node.feature, node.threshold, left, right)
+        return Node{S,T}(node.feature, node.threshold, left, right)
     end
 end
 
-function update_using_impurity!(feature_importance::Vector{Float64}, node::treeregressor.NodeMeta{S}) where S
+function update_using_impurity!(
+    feature_importance::Vector{Float64}, node::treeregressor.NodeMeta{S}
+) where {S}
     if !node.is_leaf
         update_using_impurity!(feature_importance, node.l)
         update_using_impurity!(feature_importance, node.r)
-        feature_importance[node.feature] += node.node_impurity - node.l.node_impurity - node.r.node_impurity
+        feature_importance[node.feature] +=
+            node.node_impurity - node.l.node_impurity - node.r.node_impurity
     end
-    return
+    return nothing
 end
 
-function build_stump(labels::AbstractVector{T}, features::AbstractMatrix{S}; rng = Random.GLOBAL_RNG, impurity_importance::Bool = true) where {S, T <: Float64}
-    return build_tree(labels, features, 0, 1; rng=rng, impurity_importance=impurity_importance)
+function build_stump(
+    labels::AbstractVector{T},
+    features::AbstractMatrix{S};
+    rng=Random.GLOBAL_RNG,
+    impurity_importance::Bool=true,
+) where {S,T<:Float64}
+    return build_tree(labels, features, 0, 1; rng, impurity_importance)
 end
 
 function build_tree(
-        labels             :: AbstractVector{T},
-        features           :: AbstractMatrix{S},
-        n_subfeatures       = 0,
-        max_depth           = -1,
-        min_samples_leaf    = 5,
-        min_samples_split   = 2,
-        min_purity_increase = 0.0;
-        rng                 = Random.GLOBAL_RNG,
-        impurity_importance:: Bool = true) where {S, T <: Float64}
-
+    labels::AbstractVector{T},
+    features::AbstractMatrix{S},
+    n_subfeatures=0,
+    max_depth=-1,
+    min_samples_leaf=5,
+    min_samples_split=2,
+    min_purity_increase=0.0;
+    rng=Random.GLOBAL_RNG,
+    impurity_importance::Bool=true,
+) where {S,T<:Float64}
     if max_depth == -1
         max_depth = typemax(Int)
     end
@@ -42,41 +50,42 @@ function build_tree(
     end
 
     rng = mk_rng(rng)::Random.AbstractRNG
-    t = treeregressor.fit(
-        X                   = features,
-        Y                   = labels,
-        W                   = nothing,
-        max_features        = Int(n_subfeatures),
-        max_depth           = Int(max_depth),
-        min_samples_leaf    = Int(min_samples_leaf),
-        min_samples_split   = Int(min_samples_split),
-        min_purity_increase = Float64(min_purity_increase),
-        rng                 = rng)
+    t = treeregressor.fit(;
+        X=features,
+        Y=labels,
+        W=nothing,
+        max_features=Int(n_subfeatures),
+        max_depth=Int(max_depth),
+        min_samples_leaf=Int(min_samples_leaf),
+        min_samples_split=Int(min_samples_split),
+        min_purity_increase=Float64(min_purity_increase),
+        rng,
+    )
 
     node = _convert(t.root, labels[t.labels])
     n_features = size(features, 2)
     if !impurity_importance
-        return Root{S, T}(node, n_features, Float64[])
+        return Root{S,T}(node, n_features, Float64[])
     else
         fi = zeros(Float64, n_features)
         update_using_impurity!(fi, t.root)
-        return Root{S, T}(node, n_features, fi ./ size(features, 1))
+        return Root{S,T}(node, n_features, fi ./ size(features, 1))
     end
 end
 
 function build_forest(
-        labels              :: AbstractVector{T},
-        features            :: AbstractMatrix{S},
-        n_subfeatures       = -1,
-        n_trees             = 10,
-        partial_sampling    = 0.7,
-        max_depth           = -1,
-        min_samples_leaf    = 5,
-        min_samples_split   = 2,
-        min_purity_increase = 0.0;
-        rng::Union{Integer,AbstractRNG} = Random.GLOBAL_RNG,
-        impurity_importance :: Bool = true) where {S, T <: Float64}
-
+    labels::AbstractVector{T},
+    features::AbstractMatrix{S},
+    n_subfeatures=-1,
+    n_trees=10,
+    partial_sampling=0.7,
+    max_depth=-1,
+    min_samples_leaf=5,
+    min_samples_split=2,
+    min_purity_increase=0.0;
+    rng::Union{Integer,AbstractRNG}=Random.GLOBAL_RNG,
+    impurity_importance::Bool=true,
+) where {S,T<:Float64}
     if n_trees < 1
         throw("the number of trees must be >= 1")
     end
@@ -92,7 +101,11 @@ function build_forest(
     t_samples = length(labels)
     n_samples = floor(Int, partial_sampling * t_samples)
 
-    forest = impurity_importance ? Vector{Root{S, T}}(undef, n_trees) : Vector{LeafOrNode{S, T}}(undef, n_trees)
+    forest = if impurity_importance
+        Vector{Root{S,T}}(undef, n_trees)
+    else
+        Vector{LeafOrNode{S,T}}(undef, n_trees)
+    end
 
     if rng isa Random.AbstractRNG
         shared_seed = rand(rng, UInt)
@@ -102,14 +115,15 @@ function build_forest(
             inds = rand(_rng, 1:t_samples, n_samples)
             forest[i] = build_tree(
                 labels[inds],
-                features[inds,:],
+                features[inds, :],
                 n_subfeatures,
                 max_depth,
                 min_samples_leaf,
                 min_samples_split,
-                min_purity_increase,
-                rng = _rng,
-                impurity_importance = impurity_importance)
+                min_purity_increase;
+                rng=_rng,
+                impurity_importance=impurity_importance,
+            )
         end
     else # each thread gets its own seeded rng
         Threads.@threads for i in 1:n_trees
@@ -117,13 +131,14 @@ function build_forest(
             inds = rand(1:t_samples, n_samples)
             forest[i] = build_tree(
                 labels[inds],
-                features[inds,:],
+                features[inds, :],
                 n_subfeatures,
                 max_depth,
                 min_samples_leaf,
                 min_samples_split,
-                min_purity_increase,
-                impurity_importance = impurity_importance)
+                min_purity_increase;
+                impurity_importance,
+            )
         end
     end
 

--- a/src/regression/main.jl
+++ b/src/regression/main.jl
@@ -122,7 +122,7 @@ function build_forest(
                 min_samples_split,
                 min_purity_increase;
                 rng=_rng,
-                impurity_importance=impurity_importance,
+                impurity_importance,
             )
         end
     else # each thread gets its own seeded rng

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -5,28 +5,29 @@
 # written by Poom Chiarawongse <eight1911@gmail.com>
 
 module treeregressor
-    include("../util.jl")
+include("../util.jl")
 
-    import Random
-    export fit
+using Random: Random
+export fit
 
-    mutable struct NodeMeta{S}
-        l               :: NodeMeta{S}  # right child
-        r               :: NodeMeta{S}  # left child
-        label           :: Float64      # most likely label
-        feature         :: Int          # feature used for splitting
-        threshold       :: S            # threshold value
-        is_leaf         :: Bool
-        depth           :: Int
-        region          :: UnitRange{Int} # a slice of the samples used to decide the split of the node
-        features        :: Vector{Int}    # a list of features not known to be constant
-        split_at        :: Int            # index of samples
-        node_impurity   :: Float64
-        function NodeMeta{S}(
-            features        :: Vector{Int},
-            region          :: UnitRange{Int},
-            depth           :: Int,
-            node_impurity   :: Float64 = 0.0) where S
+mutable struct NodeMeta{S}
+    l::NodeMeta{S}  # right child
+    r::NodeMeta{S}  # left child
+    label::Float64      # most likely label
+    feature::Int          # feature used for splitting
+    threshold::S            # threshold value
+    is_leaf::Bool
+    depth::Int
+    region::UnitRange{Int} # a slice of the samples used to decide the split of the node
+    features::Vector{Int}    # a list of features not known to be constant
+    split_at::Int            # index of samples
+    node_impurity::Float64
+    function NodeMeta{S}(
+        features::Vector{Int},
+        region::UnitRange{Int},
+        depth::Int,
+        node_impurity::Float64=0.0,
+    ) where {S}
         node = new{S}()
         node.depth = depth
         node.region = region
@@ -35,285 +36,300 @@ module treeregressor
         node.node_impurity = node_impurity
         node
     end
+end
+
+struct Tree{S}
+    root::NodeMeta{S}
+    labels::Vector{Int}
+end
+
+# find an optimal split that satisfy the given constraints
+# (max_depth, min_samples_split, min_purity_increase)
+function _split!(
+    X::AbstractMatrix{S}, # the feature array
+    Y::AbstractVector{Float64}, # the label array
+    W::AbstractVector{U},
+    node::NodeMeta{S}, # the node to split
+    max_features::Int, # number of features to consider
+    max_depth::Int, # the maximum depth of the resultant tree
+    min_samples_leaf::Int, # the minimum number of samples each leaf needs to have
+    min_samples_split::Int, # the minimum number of samples in needed for a split
+    min_purity_increase::Float64, # minimum purity needed for a split
+    indX::AbstractVector{Int}, # an array of sample indices,
+    # we split using samples in indX[node.region]
+    # the two arrays below are given for optimization purposes
+    Xf::AbstractVector{S},
+    Yf::AbstractVector{Float64},
+    Wf::AbstractVector{U},
+    rng::Random.AbstractRNG,
+) where {S,U}
+    region = node.region
+    n_samples = length(region)
+    r_start = region.start - 1
+
+    @inbounds @simd for i in 1:n_samples
+        Yf[i] = Y[indX[i + r_start]]
+        Wf[i] = W[indX[i + r_start]]
     end
 
-    struct Tree{S}
-        root   :: NodeMeta{S}
-        labels :: Vector{Int}
+    tssq = zero(U)
+    tsum = zero(U)
+    wsum = zero(U)
+    @inbounds @simd for i in 1:n_samples
+        tssq += Wf[i] * Yf[i] * Yf[i]
+        tsum += Wf[i] * Yf[i]
+        wsum += Wf[i]
     end
 
-    # find an optimal split that satisfy the given constraints
-    # (max_depth, min_samples_split, min_purity_increase)
-    function _split!(
-            X                   :: AbstractMatrix{S}, # the feature array
-            Y                   :: AbstractVector{Float64}, # the label array
-            W                   :: AbstractVector{U},
-            node                :: NodeMeta{S}, # the node to split
-            max_features        :: Int, # number of features to consider
-            max_depth           :: Int, # the maximum depth of the resultant tree
-            min_samples_leaf    :: Int, # the minimum number of samples each leaf needs to have
-            min_samples_split   :: Int, # the minimum number of samples in needed for a split
-            min_purity_increase :: Float64, # minimum purity needed for a split
-            indX                :: AbstractVector{Int}, # an array of sample indices,
-                                                # we split using samples in indX[node.region]
-            # the two arrays below are given for optimization purposes
-            Xf                  :: AbstractVector{S},
-            Yf                  :: AbstractVector{Float64},
-            Wf                  :: AbstractVector{U},
-            rng                 :: Random.AbstractRNG) where {S, U}
+    node.label = tsum / wsum
+    # Σy² - nȳ²
+    node.node_impurity = tssq - wsum * node.label^2
+    if (
+        min_samples_leaf * 2 > n_samples ||
+        min_samples_split > n_samples ||
+        max_depth <= node.depth
+        # equivalent to old_purity > -1e-7
+        ||
+        tsum * node.label > -1e-7 * wsum + tssq
+    )
+        # TODO : Add Wf[1:n_samples] to this thing
+        node.is_leaf = true
+        return nothing
+    end
 
-        region = node.region
-        n_samples = length(region)
-        r_start = region.start - 1
+    features = node.features
+    n_features = length(features)
+    best_purity = typemin(U)
+    best_feature = -1
+    threshold_lo = X[1]
+    threshold_hi = X[1]
 
-        @inbounds @simd for i in 1:n_samples
+    indf = 1
+    # the number of new constants found during this split
+    n_constant = 0
+    # true if every feature is constant
+    unsplittable = true
+    # the number of non constant features we will see if
+    # only sample n_features used features
+    # is a hypergeometric random variable
+    total_features = size(X, 2)
+
+    # this is the total number of features that we expect to not
+    # be one of the known constant features. since we know exactly
+    # what the non constant features are, we can sample at 'non_constants_used'
+    # non constant features instead of going through every feature randomly.
+    non_constants_used = util.hypergeometric(
+        n_features, total_features - n_features, max_features, rng
+    )
+    @inbounds while (unsplittable || indf <= non_constants_used) && indf <= n_features
+        feature = let
+            indr = rand(rng, indf:n_features)
+            features[indf], features[indr] = features[indr], features[indf]
+            features[indf]
+        end
+
+        rssq = tssq
+        lssq = zero(U)
+        rsum = tsum
+        lsum = zero(U)
+
+        @simd for i in 1:n_samples
+            Xf[i] = X[indX[i + r_start], feature]
+        end
+
+        # sort Yf and indX by Xf
+        util.q_bi_sort!(Xf, indX, 1, n_samples, r_start)
+        @simd for i in 1:n_samples
             Yf[i] = Y[indX[i + r_start]]
             Wf[i] = W[indX[i + r_start]]
         end
-
-        tssq = zero(U)
-        tsum = zero(U)
-        wsum = zero(U)
-        @inbounds @simd for i in 1:n_samples
-            tssq += Wf[i]*Yf[i]*Yf[i]
-            tsum += Wf[i]*Yf[i]
-            wsum += Wf[i]
-        end
-
-        node.label =  tsum / wsum
-        # Σy² - nȳ²
-        node.node_impurity = tssq  - wsum * node.label ^ 2
-        if (min_samples_leaf * 2 >  n_samples
-         || min_samples_split    >  n_samples
-         || max_depth            <= node.depth
-          # equivalent to old_purity > -1e-7
-         || tsum * node.label    > -1e-7 * wsum + tssq)
-            # TODO : Add Wf[1:n_samples] to this thing
-            node.is_leaf = true
-            return
-        end
-
-        features = node.features
-        n_features = length(features)
-        best_purity = typemin(U)
-        best_feature = -1
-        threshold_lo = X[1]
-        threshold_hi = X[1]
-
-        indf = 1
-        # the number of new constants found during this split
-        n_constant = 0
-        # true if every feature is constant
-        unsplittable = true
-        # the number of non constant features we will see if
-        # only sample n_features used features
-        # is a hypergeometric random variable
-        total_features = size(X, 2)
-
-        # this is the total number of features that we expect to not
-        # be one of the known constant features. since we know exactly
-        # what the non constant features are, we can sample at 'non_constants_used'
-        # non constant features instead of going through every feature randomly.
-        non_constants_used = util.hypergeometric(n_features, total_features-n_features, max_features, rng)
-        @inbounds while (unsplittable || indf <= non_constants_used) && indf <= n_features
-            feature = let
-                indr = rand(rng, indf:n_features)
-                features[indf], features[indr] = features[indr], features[indf]
-                features[indf]
-            end
-
-            rssq = tssq
-            lssq = zero(U)
-            rsum = tsum
-            lsum = zero(U)
-
-            @simd for i in 1:n_samples
-                Xf[i] = X[indX[i + r_start], feature]
-            end
-
-            # sort Yf and indX by Xf
-            util.q_bi_sort!(Xf, indX, 1, n_samples, r_start)
-            @simd for i in 1:n_samples
-                Yf[i] = Y[indX[i + r_start]]
-                Wf[i] = W[indX[i + r_start]]
-            end
-            nl, nr = zero(U), wsum
-            # lo and hi are the indices of
-            # the least upper bound and the greatest lower bound
-            # of the left and right nodes respectively
-            hi = 0
-            last_f = Xf[1]
-            is_constant = true
-            while hi < n_samples
-                lo = hi + 1
-                curr_f = Xf[lo]
-                hi = (lo < n_samples && curr_f == Xf[lo+1]
-                    ? searchsortedlast(Xf, curr_f, lo, n_samples, Base.Order.Forward)
-                    : lo)
-
-                (lo != 1) && (is_constant = false)
-                # honor min_samples_leaf
-                if lo-1 >= min_samples_leaf && n_samples - (lo-1) >= min_samples_leaf
-                    unsplittable = false
-                    purity = (rsum * rsum / nr) + (lsum * lsum / nl)
-                    if purity > best_purity && !isapprox(purity, best_purity)
-                        # will take average at the end, if possible
-                        threshold_lo = last_f
-                        threshold_hi = curr_f
-                        best_purity  = purity
-                        best_feature = feature
-                    end
-                end
-
-                # update, lssq, rssq, lsum, rsum in the direction
-                # that would require the smaller number of iterations
-                if (hi << 1) < n_samples + lo # i.e., hi - lo < n_samples - hi
-                    @simd for i in lo:hi
-                        nr   -= Wf[i]
-                        rsum -= Wf[i]*Yf[i]
-                        rssq -= Wf[i]*Yf[i]*Yf[i]
-                    end
+        nl, nr = zero(U), wsum
+        # lo and hi are the indices of
+        # the least upper bound and the greatest lower bound
+        # of the left and right nodes respectively
+        hi = 0
+        last_f = Xf[1]
+        is_constant = true
+        while hi < n_samples
+            lo = hi + 1
+            curr_f = Xf[lo]
+            hi = (
+                if lo < n_samples && curr_f == Xf[lo + 1]
+                    searchsortedlast(Xf, curr_f, lo, n_samples, Base.Order.Forward)
                 else
-                    nr = rsum = rssq = zero(U)
-                    @simd for i in (hi+1):n_samples
-                        nr   += Wf[i]
-                        rsum += Wf[i]*Yf[i]
-                        rssq += Wf[i]*Yf[i]*Yf[i]
-                    end
+                    lo
                 end
-                lsum = tsum - rsum
-                lssq = tssq - rssq
-                nl   = wsum - nr
+            )
 
-                last_f = curr_f
+            (lo != 1) && (is_constant = false)
+            # honor min_samples_leaf
+            if lo - 1 >= min_samples_leaf && n_samples - (lo - 1) >= min_samples_leaf
+                unsplittable = false
+                purity = (rsum * rsum / nr) + (lsum * lsum / nl)
+                if purity > best_purity && !isapprox(purity, best_purity)
+                    # will take average at the end, if possible
+                    threshold_lo = last_f
+                    threshold_hi = curr_f
+                    best_purity = purity
+                    best_feature = feature
+                end
             end
 
-            # keep track of constant features to be used later.
-            if is_constant
-                n_constant += 1
-                features[indf], features[n_constant] = features[n_constant], features[indf]
+            # update, lssq, rssq, lsum, rsum in the direction
+            # that would require the smaller number of iterations
+            if (hi << 1) < n_samples + lo # i.e., hi - lo < n_samples - hi
+                @simd for i in lo:hi
+                    nr -= Wf[i]
+                    rsum -= Wf[i] * Yf[i]
+                    rssq -= Wf[i] * Yf[i] * Yf[i]
+                end
+            else
+                nr = rsum = rssq = zero(U)
+                @simd for i in (hi + 1):n_samples
+                    nr += Wf[i]
+                    rsum += Wf[i] * Yf[i]
+                    rssq += Wf[i] * Yf[i] * Yf[i]
+                end
             end
+            lsum = tsum - rsum
+            lssq = tssq - rssq
+            nl = wsum - nr
 
-            indf += 1
+            last_f = curr_f
         end
 
-        # no splits honor min_samples_leaf
-        @inbounds if (unsplittable
-                || best_purity - tsum * node.label < min_purity_increase * wsum)
-            node.is_leaf = true
-            return
-        else
-            # new_purity - old_purity < stop.min_purity_increase
-            @simd for i in 1:n_samples
-                Xf[i] = X[indX[i + r_start], best_feature]
-            end
-
-            try
-                node.threshold = (threshold_lo + threshold_hi) / 2.0
-            catch
-                node.threshold = threshold_hi
-            end
-            # split the samples into two parts: ones that are greater than
-            # the threshold and ones that are less than or equal to the threshold
-            #                                 ---------------------
-            # (so we partition at threshold_lo instead of node.threshold)
-            node.split_at = util.partition!(indX, Xf, threshold_lo, region)
-            node.feature = best_feature
-            node.features = features[(n_constant+1):n_features]
+        # keep track of constant features to be used later.
+        if is_constant
+            n_constant += 1
+            features[indf], features[n_constant] = features[n_constant], features[indf]
         end
 
+        indf += 1
     end
 
-    @inline function fork!(node :: NodeMeta{S}) where S
-        ind = node.split_at
-        region = node.region
-        features = node.features
-        # no need to copy because we will copy at the end
-        node.l = NodeMeta{S}(features, region[    1:ind], node.depth + 1)
-        node.r = NodeMeta{S}(features, region[ind+1:end], node.depth + 1)
-    end
-
-    function _fit(
-            X                     :: AbstractMatrix{S},
-            Y                     :: AbstractVector{Float64},
-            W                     :: AbstractVector{U},
-            max_features          :: Int,
-            max_depth             :: Int,
-            min_samples_leaf      :: Int,
-            min_samples_split     :: Int,
-            min_purity_increase   :: Float64,
-            rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where {S, U}
-
-        n_samples, n_features = size(X)
-
-        Yf  = Array{Float64}(undef, n_samples)
-        Xf  = Array{S}(undef, n_samples)
-        Wf  = Array{U}(undef, n_samples)
-
-        indX = collect(1:n_samples)
-        root = NodeMeta{S}(collect(1:n_features), 1:n_samples, 0)
-        stack = NodeMeta{S}[root]
-
-        @inbounds while length(stack) > 0
-            node = pop!(stack)
-            _split!(
-                X, Y, W,
-                node,
-                max_features,
-                max_depth,
-                min_samples_leaf,
-                min_samples_split,
-                min_purity_increase,
-                indX,
-                Xf, Yf, Wf,
-                rng)
-            if !node.is_leaf
-                fork!(node)
-                push!(stack, node.r)
-                push!(stack, node.l)
-            end
-        end
-        return (root, indX)
-    end
-
-    function fit(;
-            X                     :: AbstractMatrix{S},
-            Y                     :: AbstractVector{Float64},
-            W                     :: Union{Nothing, AbstractVector{U}},
-            max_features          :: Int,
-            max_depth             :: Int,
-            min_samples_leaf      :: Int,
-            min_samples_split     :: Int,
-            min_purity_increase   :: Float64,
-            rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where {S, U}
-
-        n_samples, n_features = size(X)
-        if isnothing(W)
-            W = fill(1.0, n_samples)
+    # no splits honor min_samples_leaf
+    @inbounds if (
+        unsplittable || best_purity - tsum * node.label < min_purity_increase * wsum
+    )
+        node.is_leaf = true
+        return nothing
+    else
+        # new_purity - old_purity < stop.min_purity_increase
+        @simd for i in 1:n_samples
+            Xf[i] = X[indX[i + r_start], best_feature]
         end
 
-        util.check_input(
+        try
+            node.threshold = (threshold_lo + threshold_hi) / 2.0
+        catch
+            node.threshold = threshold_hi
+        end
+        # split the samples into two parts: ones that are greater than
+        # the threshold and ones that are less than or equal to the threshold
+        #                                 ---------------------
+        # (so we partition at threshold_lo instead of node.threshold)
+        node.split_at = util.partition!(indX, Xf, threshold_lo, region)
+        node.feature = best_feature
+        node.features = features[(n_constant + 1):n_features]
+    end
+end
+
+@inline function fork!(node::NodeMeta{S}) where {S}
+    ind = node.split_at
+    region = node.region
+    features = node.features
+    # no need to copy because we will copy at the end
+    node.l = NodeMeta{S}(features, region[1:ind], node.depth + 1)
+    node.r = NodeMeta{S}(features, region[(ind + 1):end], node.depth + 1)
+end
+
+function _fit(
+    X::AbstractMatrix{S},
+    Y::AbstractVector{Float64},
+    W::AbstractVector{U},
+    max_features::Int,
+    max_depth::Int,
+    min_samples_leaf::Int,
+    min_samples_split::Int,
+    min_purity_increase::Float64,
+    rng=Random.GLOBAL_RNG::Random.AbstractRNG,
+) where {S,U}
+    n_samples, n_features = size(X)
+
+    Yf = Array{Float64}(undef, n_samples)
+    Xf = Array{S}(undef, n_samples)
+    Wf = Array{U}(undef, n_samples)
+
+    indX = collect(1:n_samples)
+    root = NodeMeta{S}(collect(1:n_features), 1:n_samples, 0)
+    stack = NodeMeta{S}[root]
+
+    @inbounds while length(stack) > 0
+        node = pop!(stack)
+        _split!(
             X,
             Y,
             W,
-            max_features,
-            max_depth,
-            min_samples_leaf,
-            min_samples_split,
-            min_purity_increase)
-
-        root, indX = _fit(
-            X,
-            Y,
-            W,
+            node,
             max_features,
             max_depth,
             min_samples_leaf,
             min_samples_split,
             min_purity_increase,
-            rng)
-
-        return Tree{S}(root, indX)
-
+            indX,
+            Xf,
+            Yf,
+            Wf,
+            rng,
+        )
+        if !node.is_leaf
+            fork!(node)
+            push!(stack, node.r)
+            push!(stack, node.l)
+        end
     end
+    return (root, indX)
+end
+
+function fit(;
+    X::AbstractMatrix{S},
+    Y::AbstractVector{Float64},
+    W::Union{Nothing,AbstractVector{U}},
+    max_features::Int,
+    max_depth::Int,
+    min_samples_leaf::Int,
+    min_samples_split::Int,
+    min_purity_increase::Float64,
+    rng=Random.GLOBAL_RNG::Random.AbstractRNG,
+) where {S,U}
+    n_samples, n_features = size(X)
+    if isnothing(W)
+        W = fill(1.0, n_samples)
+    end
+
+    util.check_input(
+        X,
+        Y,
+        W,
+        max_features,
+        max_depth,
+        min_samples_leaf,
+        min_samples_split,
+        min_purity_increase,
+    )
+
+    root, indX = _fit(
+        X,
+        Y,
+        W,
+        max_features,
+        max_depth,
+        min_samples_leaf,
+        min_samples_split,
+        min_purity_increase,
+        rng,
+    )
+
+    return Tree{S}(root, indX)
+end
 end

--- a/src/scikitlearnAPI.jl
+++ b/src/scikitlearnAPI.jl
@@ -1,5 +1,11 @@
-import ScikitLearnBase: BaseClassifier, BaseRegressor, predict, predict_proba,
-                        fit!, get_classes, @declare_hyperparameters
+import ScikitLearnBase:
+    BaseClassifier,
+    BaseRegressor,
+    predict,
+    predict_proba,
+    fit!,
+    get_classes,
+    @declare_hyperparameters
 
 ################################################################################
 # Classifier
@@ -39,30 +45,62 @@ mutable struct DecisionTreeClassifier <: BaseClassifier
     n_subfeatures::Int
     rng::Random.Random.AbstractRNG
     impurity_importance::Bool
-    root::Union{Root, Nothing}
-    classes::Union{Vector, Nothing}
-    DecisionTreeClassifier(;pruning_purity_threshold=1.0, max_depth=-1, min_samples_leaf=1, min_samples_split=2,
-                           min_purity_increase=0.0, n_subfeatures=0, rng=Random.GLOBAL_RNG, impurity_importance=true, root=nothing, classes=nothing) =
-        new(pruning_purity_threshold, max_depth, min_samples_leaf, min_samples_split,
-            min_purity_increase, n_subfeatures, mk_rng(rng), impurity_importance, root, classes)
+    root::Union{Root,Nothing}
+    classes::Union{Vector,Nothing}
+    function DecisionTreeClassifier(;
+        pruning_purity_threshold=1.0,
+        max_depth=-1,
+        min_samples_leaf=1,
+        min_samples_split=2,
+        min_purity_increase=0.0,
+        n_subfeatures=0,
+        rng=Random.GLOBAL_RNG,
+        impurity_importance=true,
+        root=nothing,
+        classes=nothing,
+    )
+        new(
+            pruning_purity_threshold,
+            max_depth,
+            min_samples_leaf,
+            min_samples_split,
+            min_purity_increase,
+            n_subfeatures,
+            mk_rng(rng),
+            impurity_importance,
+            root,
+            classes,
+        )
+    end
 end
 
 get_classes(dt::DecisionTreeClassifier) = dt.classes
-@declare_hyperparameters(DecisionTreeClassifier,
-                         [:pruning_purity_threshold, :max_depth, :min_samples_leaf,
-                          :min_samples_split, :min_purity_increase, :rng, :impurity_importance])
+@declare_hyperparameters(
+    DecisionTreeClassifier,
+    [
+        :pruning_purity_threshold,
+        :max_depth,
+        :min_samples_leaf,
+        :min_samples_split,
+        :min_purity_increase,
+        :rng,
+        :impurity_importance,
+    ]
+)
 
 function fit!(dt::DecisionTreeClassifier, X, y)
     n_samples, n_features = size(X)
     dt.root = build_tree(
-        y, X,
+        y,
+        X,
         dt.n_subfeatures,
         dt.max_depth,
         dt.min_samples_leaf,
         dt.min_samples_split,
         dt.min_purity_increase;
-        rng = dt.rng,
-        impurity_importance = dt.impurity_importance)
+        rng=dt.rng,
+        impurity_importance=dt.impurity_importance,
+    )
 
     dt.root = prune_tree(dt.root, dt.pruning_purity_threshold)
     dt.classes = sort(unique(y))
@@ -71,11 +109,9 @@ end
 
 predict(dt::DecisionTreeClassifier, X) = apply_tree(dt.root, X)
 
-predict_proba(dt::DecisionTreeClassifier, X) =
-    apply_tree_proba(dt.root, X, dt.classes)
+predict_proba(dt::DecisionTreeClassifier, X) = apply_tree_proba(dt.root, X, dt.classes)
 
-predict_log_proba(dt::DecisionTreeClassifier, X) =
-    log(predict_proba(dt, X)) # this will yield -Inf when p=0. Hmmm...
+predict_log_proba(dt::DecisionTreeClassifier, X) = log(predict_proba(dt, X)) # this will yield -Inf when p=0. Hmmm...
 
 function show(io::IO, dt::DecisionTreeClassifier)
     println(io, "DecisionTreeClassifier")
@@ -85,8 +121,11 @@ function show(io::IO, dt::DecisionTreeClassifier)
     println(io, "min_purity_increase:      $(dt.min_purity_increase)")
     println(io, "pruning_purity_threshold: $(dt.pruning_purity_threshold)")
     println(io, "n_subfeatures:            $(dt.n_subfeatures)")
-    print(io,   "classes:                  ") ; show(io, dt.classes) ; println(io, "")
-    print(io,   "root:                     ") ; show(io, dt.root)
+    print(io, "classes:                  ")
+    show(io, dt.classes)
+    println(io, "")
+    print(io, "root:                     ")
+    show(io, dt.root)
 end
 
 ################################################################################
@@ -126,10 +165,20 @@ mutable struct DecisionTreeRegressor <: BaseRegressor
     n_subfeatures::Int
     rng::Random.AbstractRNG
     impurity_importance::Bool
-    root::Union{Root, Nothing}
-    DecisionTreeRegressor(;pruning_purity_threshold=1.0, max_depth=-1, min_samples_leaf=5,
-                          min_samples_split=2, min_purity_increase=0.0, n_subfeatures=0, rng=Random.GLOBAL_RNG, impurity_importance=true, root=nothing) =
-        new(pruning_purity_threshold,
+    root::Union{Root,Nothing}
+    function DecisionTreeRegressor(;
+        pruning_purity_threshold=1.0,
+        max_depth=-1,
+        min_samples_leaf=5,
+        min_samples_split=2,
+        min_purity_increase=0.0,
+        n_subfeatures=0,
+        rng=Random.GLOBAL_RNG,
+        impurity_importance=true,
+        root=nothing,
+    )
+        new(
+            pruning_purity_threshold,
             max_depth,
             min_samples_leaf,
             min_samples_split,
@@ -137,25 +186,39 @@ mutable struct DecisionTreeRegressor <: BaseRegressor
             n_subfeatures,
             mk_rng(rng),
             impurity_importance,
-            root)
+            root,
+        )
+    end
 end
 
-@declare_hyperparameters(DecisionTreeRegressor,
-                         [:pruning_purity_threshold, :min_samples_leaf, :n_subfeatures,
-                          :max_depth, :min_samples_split, :min_purity_increase, :rng, :impurity_importance])
+@declare_hyperparameters(
+    DecisionTreeRegressor,
+    [
+        :pruning_purity_threshold,
+        :min_samples_leaf,
+        :n_subfeatures,
+        :max_depth,
+        :min_samples_split,
+        :min_purity_increase,
+        :rng,
+        :impurity_importance,
+    ]
+)
 
 function fit!(dt::DecisionTreeRegressor, X::AbstractMatrix, y::AbstractVector)
     n_samples, n_features = size(X)
     dt.root = build_tree(
-        float.(y), X,
+        float.(y),
+        X,
         dt.n_subfeatures,
         dt.max_depth,
         dt.min_samples_leaf,
         dt.min_samples_split,
         dt.min_purity_increase;
-        rng = dt.rng,
-        impurity_importance = dt.impurity_importance)
-    
+        rng=dt.rng,
+        impurity_importance=dt.impurity_importance,
+    )
+
     dt.root = prune_tree(dt.root, dt.pruning_purity_threshold)
     dt
 end
@@ -170,7 +233,8 @@ function show(io::IO, dt::DecisionTreeRegressor)
     println(io, "min_purity_increase:      $(dt.min_purity_increase)")
     println(io, "pruning_purity_threshold: $(dt.pruning_purity_threshold)")
     println(io, "n_subfeatures:            $(dt.n_subfeatures)")
-    print(io,   "root:                     ") ; show(io, dt.root)
+    print(io, "root:                     ")
+    show(io, dt.root)
 end
 
 ################################################################################
@@ -208,27 +272,60 @@ mutable struct RandomForestClassifier <: BaseClassifier
     min_samples_leaf::Int
     min_samples_split::Int
     min_purity_increase::Float64
-    rng::Union{Random.AbstractRNG, Int}
-    impurity_importance:: Bool
-    ensemble::Union{Ensemble, Nothing}
-    classes::Union{Vector, Nothing}
-    RandomForestClassifier(; n_subfeatures=-1, n_trees=10, partial_sampling=0.7,
-                           max_depth=-1, min_samples_leaf=1, min_samples_split=2, min_purity_increase=0.0,
-                           rng=Random.GLOBAL_RNG, impurity_importance=true,ensemble=nothing, classes=nothing) =
-        new(n_subfeatures, n_trees, partial_sampling, max_depth, min_samples_leaf, min_samples_split,
-            min_purity_increase, rng, impurity_importance, ensemble, classes)
+    rng::Union{Random.AbstractRNG,Int}
+    impurity_importance::Bool
+    ensemble::Union{Ensemble,Nothing}
+    classes::Union{Vector,Nothing}
+    function RandomForestClassifier(;
+        n_subfeatures=-1,
+        n_trees=10,
+        partial_sampling=0.7,
+        max_depth=-1,
+        min_samples_leaf=1,
+        min_samples_split=2,
+        min_purity_increase=0.0,
+        rng=Random.GLOBAL_RNG,
+        impurity_importance=true,
+        ensemble=nothing,
+        classes=nothing,
+    )
+        new(
+            n_subfeatures,
+            n_trees,
+            partial_sampling,
+            max_depth,
+            min_samples_leaf,
+            min_samples_split,
+            min_purity_increase,
+            rng,
+            impurity_importance,
+            ensemble,
+            classes,
+        )
+    end
 end
 
 get_classes(rf::RandomForestClassifier) = rf.classes
-@declare_hyperparameters(RandomForestClassifier,
-                         [:n_subfeatures, :n_trees, :partial_sampling, :max_depth,
-                          :min_samples_leaf, :min_samples_split, :min_purity_increase,
-                          :rng, :impurity_importance])
+@declare_hyperparameters(
+    RandomForestClassifier,
+    [
+        :n_subfeatures,
+        :n_trees,
+        :partial_sampling,
+        :max_depth,
+        :min_samples_leaf,
+        :min_samples_split,
+        :min_purity_increase,
+        :rng,
+        :impurity_importance,
+    ]
+)
 
 function fit!(rf::RandomForestClassifier, X::AbstractMatrix, y::AbstractVector)
     n_samples, n_features = size(X)
     rf.ensemble = build_forest(
-        y, X,
+        y,
+        X,
         rf.n_subfeatures,
         rf.n_trees,
         rf.partial_sampling,
@@ -236,14 +333,16 @@ function fit!(rf::RandomForestClassifier, X::AbstractMatrix, y::AbstractVector)
         rf.min_samples_leaf,
         rf.min_samples_split,
         rf.min_purity_increase;
-        rng = rf.rng,
-        impurity_importance = rf.impurity_importance)
+        rng=rf.rng,
+        impurity_importance=rf.impurity_importance,
+    )
     rf.classes = sort(unique(y))
     rf
 end
 
-predict_proba(rf::RandomForestClassifier, X) =
+function predict_proba(rf::RandomForestClassifier, X)
     apply_forest_proba(rf.ensemble, X, rf.classes)
+end
 
 predict(rf::RandomForestClassifier, X) = apply_forest(rf.ensemble, X)
 
@@ -256,8 +355,11 @@ function show(io::IO, rf::RandomForestClassifier)
     println(io, "min_samples_leaf:    $(rf.min_samples_leaf)")
     println(io, "min_samples_split:   $(rf.min_samples_split)")
     println(io, "min_purity_increase: $(rf.min_purity_increase)")
-    print(io,   "classes:             ") ; show(io, rf.classes)  ; println(io, "")
-    print(io,   "ensemble:            ") ; show(io, rf.ensemble)
+    print(io, "classes:             ")
+    show(io, rf.classes)
+    println(io, "")
+    print(io, "ensemble:            ")
+    show(io, rf.ensemble)
 end
 
 ################################################################################
@@ -296,27 +398,58 @@ mutable struct RandomForestRegressor <: BaseRegressor
     min_samples_leaf::Int
     min_samples_split::Int
     min_purity_increase::Float64
-    rng::Union{Random.AbstractRNG, Int}
+    rng::Union{Random.AbstractRNG,Int}
     impurity_importance::Bool
-    ensemble::Union{Ensemble, Nothing}
-    RandomForestRegressor(; n_subfeatures=-1, n_trees=10, partial_sampling=0.7,
-                            max_depth=-1, min_samples_leaf=5, min_samples_split=2, min_purity_increase=0.0,
-                            rng=Random.GLOBAL_RNG, impurity_importance=true, ensemble=nothing) =
-        new(n_subfeatures, n_trees, partial_sampling, max_depth, min_samples_leaf, min_samples_split,
-            min_purity_increase, rng, impurity_importance, ensemble)
+    ensemble::Union{Ensemble,Nothing}
+    function RandomForestRegressor(;
+        n_subfeatures=-1,
+        n_trees=10,
+        partial_sampling=0.7,
+        max_depth=-1,
+        min_samples_leaf=5,
+        min_samples_split=2,
+        min_purity_increase=0.0,
+        rng=Random.GLOBAL_RNG,
+        impurity_importance=true,
+        ensemble=nothing,
+    )
+        new(
+            n_subfeatures,
+            n_trees,
+            partial_sampling,
+            max_depth,
+            min_samples_leaf,
+            min_samples_split,
+            min_purity_increase,
+            rng,
+            impurity_importance,
+            ensemble,
+        )
+    end
 end
 
-@declare_hyperparameters(RandomForestRegressor,
-                         [:n_subfeatures, :n_trees, :partial_sampling,
-                          :min_samples_leaf, :min_samples_split, :min_purity_increase,
-                          # I'm not crazy about :rng being a hyperparameter,
-                          # since it'll change throughout fitting, but it works
-                          :max_depth, :rng, :impurity_importance])
+@declare_hyperparameters(
+    RandomForestRegressor,
+    [
+        :n_subfeatures,
+        :n_trees,
+        :partial_sampling,
+        :min_samples_leaf,
+        :min_samples_split,
+        :min_purity_increase,
+        # I'm not crazy about :rng being a hyperparameter,
+        # since it'll change throughout fitting, but it works
+        :max_depth,
+        :rng,
+        :impurity_importance,
+    ]
+)
 
 function fit!(rf::RandomForestRegressor, X::AbstractMatrix, y::AbstractVector)
     n_samples, n_features = size(X)
     rf.ensemble = build_forest(
-        float.(y), X,
+        float.(y),
+        X,
         rf.n_subfeatures,
         rf.n_trees,
         rf.partial_sampling,
@@ -324,8 +457,9 @@ function fit!(rf::RandomForestRegressor, X::AbstractMatrix, y::AbstractVector)
         rf.min_samples_leaf,
         rf.min_samples_split,
         rf.min_purity_increase;
-        rng = rf.rng,
-        impurity_importance = rf.impurity_importance)
+        rng=rf.rng,
+        impurity_importance=rf.impurity_importance,
+    )
     rf
 end
 
@@ -340,7 +474,8 @@ function show(io::IO, rf::RandomForestRegressor)
     println(io, "min_samples_leaf:    $(rf.min_samples_leaf)")
     println(io, "min_samples_split:   $(rf.min_samples_split)")
     println(io, "min_purity_increase: $(rf.min_purity_increase)")
-    print(io,   "ensemble:            ") ; show(io, rf.ensemble)
+    print(io, "ensemble:            ")
+    show(io, rf.ensemble)
 end
 
 ################################################################################
@@ -363,80 +498,139 @@ Implements `fit!`, `predict`, `predict_proba`, `get_classes`
 mutable struct AdaBoostStumpClassifier <: BaseClassifier
     n_iterations::Int
     rng::Random.AbstractRNG
-    ensemble::Union{Ensemble, Nothing}
-    coeffs::Union{Vector{Float64}, Nothing}
-    classes::Union{Vector, Nothing}
-    AdaBoostStumpClassifier(; n_iterations=10, rng=Random.GLOBAL_RNG, ensemble=nothing, coeffs=nothing, classes=nothing) =
+    ensemble::Union{Ensemble,Nothing}
+    coeffs::Union{Vector{Float64},Nothing}
+    classes::Union{Vector,Nothing}
+    function AdaBoostStumpClassifier(;
+        n_iterations=10,
+        rng=Random.GLOBAL_RNG,
+        ensemble=nothing,
+        coeffs=nothing,
+        classes=nothing,
+    )
         new(n_iterations, mk_rng(rng), ensemble, coeffs, classes)
+    end
 end
 
 @declare_hyperparameters(AdaBoostStumpClassifier, [:n_iterations, :rng])
 get_classes(ada::AdaBoostStumpClassifier) = ada.classes
 
 function fit!(ada::AdaBoostStumpClassifier, X, y)
-    ada.ensemble, ada.coeffs =
-        build_adaboost_stumps(y, X, ada.n_iterations; rng=ada.rng)
+    ada.ensemble, ada.coeffs = build_adaboost_stumps(y, X, ada.n_iterations; rng=ada.rng)
     ada.classes = sort(unique(y))
     ada
 end
 
-predict(ada::AdaBoostStumpClassifier, X) =
+function predict(ada::AdaBoostStumpClassifier, X)
     apply_adaboost_stumps(ada.ensemble, ada.coeffs, X)
+end
 
-predict_proba(ada::AdaBoostStumpClassifier, X) =
+function predict_proba(ada::AdaBoostStumpClassifier, X)
     apply_adaboost_stumps_proba(ada.ensemble, ada.coeffs, X, ada.classes)
+end
 
 function show(io::IO, ada::AdaBoostStumpClassifier)
     println(io, "AdaBoostStumpClassifier")
     println(io, "n_iterations: $(ada.n_iterations)")
-    print(io,   "classes:      ") ; show(io, ada.classes)  ; println(io, "")
-    print(io,   "ensemble:     ") ; show(io, ada.ensemble)
+    print(io, "classes:      ")
+    show(io, ada.classes)
+    println(io, "")
+    print(io, "ensemble:     ")
+    show(io, ada.ensemble)
 end
 
 ################################################################################
 # Common functions
 
-depth(dt::DecisionTreeClassifier)   = depth(dt.root)
-depth(dt::DecisionTreeRegressor)    = depth(dt.root)
+depth(dt::DecisionTreeClassifier) = depth(dt.root)
+depth(dt::DecisionTreeRegressor) = depth(dt.root)
 
-length(dt::DecisionTreeClassifier)  = length(dt.root)
-length(dt::DecisionTreeRegressor)   = length(dt.root)
+length(dt::DecisionTreeClassifier) = length(dt.root)
+length(dt::DecisionTreeRegressor) = length(dt.root)
 
-print_tree(dt::DecisionTreeClassifier, depth=-1; kwargs...) = print_tree(dt.root, depth; kwargs...)
-print_tree(io::IO, dt::DecisionTreeClassifier, depth=-1; kwargs...) = print_tree(io, dt.root, depth; kwargs...)
-print_tree(dt::DecisionTreeRegressor, depth=-1; kwargs...) = print_tree(dt.root, depth; kwargs...)
-print_tree(io::IO, dt::DecisionTreeRegressor,  depth=-1; kwargs...) = print_tree(io, dt.root, depth; kwargs...)
+function print_tree(dt::DecisionTreeClassifier, depth=-1; kwargs...)
+    print_tree(dt.root, depth; kwargs...)
+end
+function print_tree(io::IO, dt::DecisionTreeClassifier, depth=-1; kwargs...)
+    print_tree(io, dt.root, depth; kwargs...)
+end
+function print_tree(dt::DecisionTreeRegressor, depth=-1; kwargs...)
+    print_tree(dt.root, depth; kwargs...)
+end
+function print_tree(io::IO, dt::DecisionTreeRegressor, depth=-1; kwargs...)
+    print_tree(io, dt.root, depth; kwargs...)
+end
 print_tree(n::Nothing, depth=-1; kwargs...) = show(n)
 
 #################################################################################
 # Trait functions
-model(dt::Union{DecisionTreeClassifier, DecisionTreeRegressor}) = dt.root
-model(rf::Union{RandomForestClassifier, RandomForestRegressor}) = rf.ensemble
+model(dt::Union{DecisionTreeClassifier,DecisionTreeRegressor}) = dt.root
+model(rf::Union{RandomForestClassifier,RandomForestRegressor}) = rf.ensemble
 model(ada::AdaBoostStumpClassifier) = ada.ensemble
 
-score_fn(::Type{<: Union{DecisionTreeClassifier, RandomForestClassifier, AdaBoostStumpClassifier}}) = accuracy
-score_fn(::Type{<: Union{DecisionTreeRegressor, RandomForestRegressor}}) = R2
+function score_fn(
+    ::Type{<:Union{DecisionTreeClassifier,RandomForestClassifier,AdaBoostStumpClassifier}}
+)
+    accuracy
+end
+score_fn(::Type{<:Union{DecisionTreeRegressor,RandomForestRegressor}}) = R2
 
 # score function
-R2(model::T, X::AbstractMatrix, y::AbstractVector) where {T <: Union{DecisionTreeClassifier, RandomForestClassifier, AdaBoostStumpClassifier, DecisionTreeRegressor, RandomForestRegressor}}= 
+function R2(
+    model::T, X::AbstractMatrix, y::AbstractVector
+) where {
+    T<:Union{
+        DecisionTreeClassifier,
+        RandomForestClassifier,
+        AdaBoostStumpClassifier,
+        DecisionTreeRegressor,
+        RandomForestRegressor,
+    },
+}
     R2(y, predict(model, X))
-accuracy(model::T, X::AbstractMatrix, y::AbstractVector) where {T <: Union{DecisionTreeClassifier, RandomForestClassifier, AdaBoostStumpClassifier, DecisionTreeRegressor, RandomForestRegressor}}= 
+end
+function accuracy(
+    model::T, X::AbstractMatrix, y::AbstractVector
+) where {
+    T<:Union{
+        DecisionTreeClassifier,
+        RandomForestClassifier,
+        AdaBoostStumpClassifier,
+        DecisionTreeRegressor,
+        RandomForestRegressor,
+    },
+}
     accuracy(y, predict(model, X))
+end
 
-const DecisionTreeEstimator = Union{DecisionTreeClassifier, RandomForestClassifier, AdaBoostStumpClassifier, DecisionTreeRegressor, RandomForestRegressor}
+const DecisionTreeEstimator = Union{
+    DecisionTreeClassifier,
+    RandomForestClassifier,
+    AdaBoostStumpClassifier,
+    DecisionTreeRegressor,
+    RandomForestRegressor,
+}
 
 # feature importances
-impurity_importance(trees::T; normalize::Bool = false) where {T <: DecisionTreeEstimator} = 
-    impurity_importance(model(trees), normalize = normalize)
+function impurity_importance(
+    trees::T; normalize::Bool=false
+) where {T<:DecisionTreeEstimator}
+    impurity_importance(model(trees); normalize)
+end
 
-impurity_importance(ada::T; normalize::Bool = false) where {T <: AdaBoostStumpClassifier} = 
-    impurity_importance(ada.ensemble, ada.coeffs, normalize = normalize)
+function impurity_importance(
+    ada::T; normalize::Bool=false
+) where {T<:AdaBoostStumpClassifier}
+    impurity_importance(ada.ensemble, ada.coeffs; normalize)
+end
 
-split_importance(trees::T; normalize::Bool = false) where {T <: DecisionTreeEstimator} = 
-    split_importance(model(trees), normalize = normalize)
+function split_importance(trees::T; normalize::Bool=false) where {T<:DecisionTreeEstimator}
+    split_importance(model(trees); normalize)
+end
 
-split_importance(ada::T; normalize::Bool = false) where {T <: AdaBoostStumpClassifier} = 
-    split_importance(ada.ensemble, ada.coeffs, normalize = normalize)
+function split_importance(ada::T; normalize::Bool=false) where {T<:AdaBoostStumpClassifier}
+    split_importance(ada.ensemble, ada.coeffs; normalize)
+end
 
 """
     permutation_importance(
@@ -454,13 +648,13 @@ The arguments and outputs are similar to `permutation_importance` for generic `D
 For `DecisionTreeClassifier`, `RandomForestClassifier` and `AdaBoostStumpClassifier`, the default is `accuracy`; for `DecisionTreeRegressor` and `RandomForestRegressor`, it is `R2`.
 """
 function permutation_importance(
-                        trees   :: T, 
-                        X       :: AbstractMatrix,
-                        y       :: AbstractVector; 
-                        score   :: Function = score_fn(T),
-                        n_iter  :: Int = 3,
-                        rng     =  Random.GLOBAL_RNG
-                        ) where {T <: DecisionTreeEstimator}
+    trees::T,
+    X::AbstractMatrix,
+    y::AbstractVector;
+    score::Function=score_fn(T),
+    n_iter::Int=3,
+    rng=Random.GLOBAL_RNG,
+) where {T<:DecisionTreeEstimator}
     base = score(trees, X, y)
     scores = Matrix{Float64}(undef, size(X, 2), n_iter)
     rng = mk_rng(rng)::Random.AbstractRNG
@@ -473,11 +667,19 @@ function permutation_importance(
         X[:, i] = origin
     end
 
-    (mean = reshape(mapslices(scores, dims = 2) do im
-        mean(im)
-    end, :), 
-    std = reshape(mapslices(scores, dims = 2) do im
-        std(im)
-    end, :), 
-    scores = scores)
+    (
+        mean=reshape(
+            mapslices(scores; dims=2) do im
+                mean(im)
+            end,
+            :,
+        ),
+        std=reshape(
+            mapslices(scores; dims=2) do im
+                std(im)
+            end,
+            :,
+        ),
+        scores=scores,
+    )
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -3,329 +3,352 @@
 
 module util
 
-    export gini, entropy, zero_one, q_bi_sort!, hypergeometric, check_input
+export gini, entropy, zero_one, q_bi_sort!, hypergeometric, check_input
 
-    function assign(Y :: AbstractVector{T}, list :: AbstractVector{T}) where T
-        dict = Dict{T, Int}()
-        @simd for i in 1:length(list)
-            @inbounds dict[list[i]] = i
-        end
-
-        _Y = Array{Int}(undef, length(Y))
-        @simd for i in 1:length(Y)
-            @inbounds _Y[i] = dict[Y[i]]
-        end
-
-        return list, _Y
+function assign(Y::AbstractVector{T}, list::AbstractVector{T}) where {T}
+    dict = Dict{T,Int}()
+    @simd for i in 1:length(list)
+        @inbounds dict[list[i]] = i
     end
 
-    function assign(Y :: AbstractVector{T}) where T
-        set = Set{T}()
-        for y in Y
-            push!(set, y)
+    _Y = Array{Int}(undef, length(Y))
+    @simd for i in 1:length(Y)
+        @inbounds _Y[i] = dict[Y[i]]
+    end
+
+    return list, _Y
+end
+
+function assign(Y::AbstractVector{T}) where {T}
+    set = Set{T}()
+    for y in Y
+        push!(set, y)
+    end
+    list = collect(set)
+    return assign(Y, list)
+end
+
+@inline function zero_one(ns, n)
+    return 1.0 - maximum(ns) / n
+end
+
+@inline function gini(ns, n)
+    s = 0.0
+    @simd for k in ns
+        s += k * (n - k)
+    end
+    return s / (n * n)
+end
+
+# compute table of values i*log(i) for integers in 0 <= i <= maxvalue
+# where tables[i+1] = i * log(i)
+# (0*log(0) is set to 0 for convenience when computing entropy)
+function compute_entropy_terms(maxvalue)
+    entropy_terms = zeros(Float64, maxvalue + 1)
+    for i in 1:maxvalue
+        entropy_terms[i + 1] = i * log(i)
+    end
+    return entropy_terms
+end
+
+# returns the entropy of ns/n, ns is an array of integers
+# and entropy_terms are precomputed entropy terms
+@inline function entropy(ns::AbstractVector{U}, n, entropy_terms) where {U<:Integer}
+    s = 0.0
+    for k in ns
+        s += entropy_terms[k + 1]
+    end
+    return log(n) - s / n
+end
+
+@inline function entropy(ns, n)
+    s = 0.0
+    @simd for k in ns
+        if k > 0
+            s += k * log(k)
         end
-        list = collect(set)
-        return assign(Y, list)
     end
+    return log(n) - s / n
+end
 
-    @inline function zero_one(ns, n)
-        return 1.0 - maximum(ns) / n
-    end
-
-    @inline function gini(ns, n)
-        s = 0.0
-        @simd for k in ns
-            s += k * (n - k)
+# adapted from the Julia Base.Sort Library
+@inline function partition!(v, w, pivot, region)
+    i, j = 1, length(region)
+    r_start = region.start - 1
+    @inbounds while true
+        while w[i] <= pivot
+            i += 1
         end
-        return s / (n * n)
-    end
-
-    # compute table of values i*log(i) for integers in 0 <= i <= maxvalue
-    # where tables[i+1] = i * log(i)
-    # (0*log(0) is set to 0 for convenience when computing entropy)
-    function compute_entropy_terms(maxvalue)
-        entropy_terms = zeros(Float64, maxvalue+1)
-        for i in 1:maxvalue
-            entropy_terms[i+1] = i * log(i)
+        while w[j] > pivot
+            j -= 1
         end
-        return entropy_terms
+        i >= j && break
+        ri = r_start + i
+        rj = r_start + j
+        v[ri], v[rj] = v[rj], v[ri]
+        w[i], w[j] = w[j], w[i]
+        i += 1
+        j -= 1
     end
+    return j
+end
 
-    # returns the entropy of ns/n, ns is an array of integers
-    # and entropy_terms are precomputed entropy terms
-    @inline function entropy(ns::AbstractVector{U}, n, entropy_terms) where {U <: Integer}
-        s = 0.0
-        for k in ns
-            s += entropy_terms[k+1]
+# adapted from the Julia Base.Sort Library
+function insert_sort!(v, w, lo, hi, offset)
+    @inbounds for i in (lo + 1):hi
+        j = i
+        x = v[i]
+        y = w[offset + i]
+        while j > lo
+            if x < v[j - 1]
+                v[j] = v[j - 1]
+                w[offset + j] = w[offset + j - 1]
+                j -= 1
+                continue
+            end
+            break
         end
-        return log(n) - s / n
+        v[j] = x
+        w[offset + j] = y
     end
+    return v
+end
 
-    @inline function entropy(ns, n)
-        s = 0.0
-        @simd for k in ns
-            if k > 0
-                s += k * log(k)
+@inline function _selectpivot!(v, w, lo, hi, offset)
+    @inbounds begin
+        mi = (lo + hi) >>> 1
+
+        # sort the values in v[lo], v[mi], v[hi]
+
+        if v[mi] < v[lo]
+            v[mi], v[lo] = v[lo], v[mi]
+            w[offset + mi], w[offset + lo] = w[offset + lo], w[offset + mi]
+        end
+        if v[hi] < v[mi]
+            if v[hi] < v[lo]
+                v[lo], v[mi], v[hi] = v[hi], v[lo], v[mi]
+                w[offset + lo], w[offset + mi], w[offset + hi] = w[offset + hi],
+                w[offset + lo],
+                w[offset + mi]
+            else
+                v[hi], v[mi] = v[mi], v[hi]
+                w[offset + hi], w[offset + mi] = w[offset + mi], w[offset + hi]
             end
         end
-        return log(n) - s / n
+
+        # move v[mi] to v[lo] and use it as the pivot
+        v[lo], v[mi] = v[mi], v[lo]
+        w[offset + lo], w[offset + mi] = w[offset + mi], w[offset + lo]
+        v_piv = v[lo]
+        w_piv = w[offset + lo]
     end
 
-    # adapted from the Julia Base.Sort Library
-    @inline function partition!(v, w, pivot, region)
-        i, j = 1, length(region)
-        r_start = region.start - 1
-        @inbounds while true
-            while w[i] <= pivot; i += 1; end;
-            while w[j]  > pivot; j -= 1; end;
-            i >= j && break
-            ri = r_start + i
-            rj = r_start + j
-            v[ri], v[rj] = v[rj], v[ri]
-            w[i], w[j] = w[j], w[i]
-            i += 1; j -= 1
+    # return the pivot
+    return v_piv, w_piv
+end
+
+# adapted from the Julia Base.Sort Library
+@inline function _bi_partition!(v, w, lo, hi, offset)
+    pivot, w_piv = _selectpivot!(v, w, lo, hi, offset)
+    # pivot == v[lo], v[hi] > pivot
+    i, j = lo, hi
+    @inbounds while true
+        i += 1
+        j -= 1
+        while v[i] < pivot
+            i += 1
         end
-        return j
+        while pivot < v[j]
+            j -= 1
+        end
+        i >= j && break
+        v[i], v[j] = v[j], v[i]
+        w[offset + i], w[offset + j] = w[offset + j], w[offset + i]
+    end
+    v[j], v[lo] = pivot, v[j]
+    w[offset + j], w[offset + lo] = w_piv, w[offset + j]
+
+    # v[j] == pivot
+    # v[k] >= pivot for k > j
+    # v[i] <= pivot for i < j
+    return j
+end
+
+# adapted from the Julia Base.Sort Library
+# adapted from the Julia Base.Sort Library
+# this sorts v[lo:hi] and w[offset+lo, offset+hi]
+# simultaneously by the values in v[lo:hi]
+const SMALL_THRESHOLD = 20
+function q_bi_sort!(v, w, lo, hi, offset)
+    @inbounds while lo < hi
+        hi - lo <= SMALL_THRESHOLD && return insert_sort!(v, w, lo, hi, offset)
+        j = _bi_partition!(v, w, lo, hi, offset)
+        if j - lo < hi - j
+            # recurse on the smaller chunk
+            # this is necessary to preserve O(log(n))
+            # stack space in the worst case (rather than O(n))
+            lo < (j - 1) && q_bi_sort!(v, w, lo, j - 1, offset)
+            lo = j + 1
+        else
+            j + 1 < hi && q_bi_sort!(v, w, j + 1, hi, offset)
+            hi = j - 1
+        end
+    end
+    return v
+end
+
+# The code function below is a small port from numpy's library
+# library which is distributed under the 3-Clause BSD license.
+# The rest of DecisionTree.jl is released under the MIT license.
+
+# ported by Poom Chiarawongse <eight1911@gmail.com>
+
+# this is the code for efficient generation
+# of hypergeometric random variables ported from numpy.random
+function hypergeometric(good, bad, sample, rng)
+    @inline function loggam(x)
+        x0 = x
+        n = 0
+        if (x == 1.0 || x == 2.0)
+            return 0.0
+        elseif x <= 7.0
+            n = Int(floor(7 - x))
+            x0 = x + n
+        end
+        x2 = 1.0 / (x0 * x0)
+        xp = 6.2831853071795864769252867665590 # Tau
+        gl0 = -1.39243221690590e+00
+        gl0 = gl0 * x2 + 1.796443723688307e-01
+        gl0 = gl0 * x2 - 2.955065359477124e-02
+        gl0 = gl0 * x2 + 6.410256410256410e-03
+        gl0 = gl0 * x2 - 1.917526917526918e-03
+        gl0 = gl0 * x2 + 8.417508417508418e-04
+        gl0 = gl0 * x2 - 5.952380952380952e-04
+        gl0 = gl0 * x2 + 7.936507936507937e-04
+        gl0 = gl0 * x2 - 2.777777777777778e-03
+        gl0 = gl0 * x2 + 8.333333333333333e-02
+        gl = gl0 / x0 + 0.5 * log(xp) + (x0 - 0.5) * log(x0) - x0
+        if x <= 7.0
+            @simd for k in 1:n
+                gl -= log(x0 - k)
+            end
+        end
+        return gl
     end
 
-    # adapted from the Julia Base.Sort Library
-    function insert_sort!(v, w, lo, hi, offset)
-        @inbounds for i = lo+1:hi
-            j = i
-            x = v[i]
-            y = w[offset+i]
-            while j > lo
-                if x < v[j-1]
-                    v[j] = v[j-1]
-                    w[offset+j] = w[offset+j-1]
-                    j -= 1
-                    continue
-                end
+    @inline function hypergeometric_hyp(good, bad, sample)
+        d1 = bad + good - sample
+        d2 = min(bad, good)
+
+        Y = d2
+        K = sample
+        while Y > 0
+            Y -= floor(UInt, rand(rng) + Y / (d1 + K))
+            K -= 1
+            if K == 0
                 break
             end
-            v[j] = x
-            w[offset+j] = y
-        end
-        return v
-    end
-
-    @inline function _selectpivot!(v, w, lo, hi, offset)
-        @inbounds begin
-            mi = (lo+hi)>>>1
-
-            # sort the values in v[lo], v[mi], v[hi]
-
-            if v[mi] < v[lo]
-                v[mi], v[lo] = v[lo], v[mi]
-                w[offset+mi], w[offset+lo] = w[offset+lo], w[offset+mi]
-            end
-            if v[hi] < v[mi]
-                if v[hi] < v[lo]
-                    v[lo], v[mi], v[hi] = v[hi], v[lo], v[mi]
-                    w[offset+lo], w[offset+mi], w[offset+hi] = w[offset+hi], w[offset+lo], w[offset+mi]
-                else
-                    v[hi], v[mi] = v[mi], v[hi]
-                    w[offset+hi], w[offset+mi] = w[offset+mi], w[offset+hi]
-                end
-            end
-
-            # move v[mi] to v[lo] and use it as the pivot
-            v[lo], v[mi] = v[mi], v[lo]
-            w[offset+lo], w[offset+mi] = w[offset+mi], w[offset+lo]
-            v_piv = v[lo]
-            w_piv = w[offset+lo]
         end
 
-        # return the pivot
-        return v_piv, w_piv
-    end
-
-    # adapted from the Julia Base.Sort Library
-    @inline function _bi_partition!(v, w, lo, hi, offset)
-        pivot, w_piv = _selectpivot!(v, w, lo, hi, offset)
-        # pivot == v[lo], v[hi] > pivot
-        i, j = lo, hi
-        @inbounds while true
-            i += 1; j -= 1
-            while v[i] < pivot; i += 1; end;
-            while pivot < v[j]; j -= 1; end;
-            i >= j && break
-            v[i], v[j] = v[j], v[i]
-            w[offset+i], w[offset+j] = w[offset+j], w[offset+i]
-        end
-        v[j], v[lo] = pivot, v[j]
-        w[offset+j], w[offset+lo] = w_piv, w[offset+j]
-
-        # v[j] == pivot
-        # v[k] >= pivot for k > j
-        # v[i] <= pivot for i < j
-        return j
-    end
-
-
-    # adapted from the Julia Base.Sort Library
-    # adapted from the Julia Base.Sort Library
-    # this sorts v[lo:hi] and w[offset+lo, offset+hi]
-    # simultaneously by the values in v[lo:hi]
-    const SMALL_THRESHOLD  = 20
-    function q_bi_sort!(v, w, lo, hi, offset)
-        @inbounds while lo < hi
-            hi-lo <= SMALL_THRESHOLD && return insert_sort!(v, w, lo, hi, offset)
-            j = _bi_partition!(v, w, lo, hi, offset)
-            if j-lo < hi-j
-                # recurse on the smaller chunk
-                # this is necessary to preserve O(log(n))
-                # stack space in the worst case (rather than O(n))
-                lo < (j-1) && q_bi_sort!(v, w, lo, j-1, offset)
-                lo = j+1
-            else
-                j+1 < hi && q_bi_sort!(v, w, j+1, hi, offset)
-                hi = j-1
-            end
-        end
-        return v
-    end
-
-
-    # The code function below is a small port from numpy's library
-    # library which is distributed under the 3-Clause BSD license.
-    # The rest of DecisionTree.jl is released under the MIT license.
-
-    # ported by Poom Chiarawongse <eight1911@gmail.com>
-
-    # this is the code for efficient generation
-    # of hypergeometric random variables ported from numpy.random
-    function hypergeometric(good, bad, sample, rng)
-
-        @inline function loggam(x)
-            x0 = x
-            n = 0
-            if (x == 1.0 || x == 2.0)
-                return 0.0
-            elseif x <= 7.0
-                n = Int(floor(7 - x))
-                x0 = x + n
-            end
-            x2 = 1.0 / (x0*x0)
-            xp = 6.2831853071795864769252867665590 # Tau
-            gl0 = -1.39243221690590e+00
-            gl0 = gl0 * x2 + 1.796443723688307e-01
-            gl0 = gl0 * x2 - 2.955065359477124e-02
-            gl0 = gl0 * x2 + 6.410256410256410e-03
-            gl0 = gl0 * x2 - 1.917526917526918e-03
-            gl0 = gl0 * x2 + 8.417508417508418e-04
-            gl0 = gl0 * x2 - 5.952380952380952e-04
-            gl0 = gl0 * x2 + 7.936507936507937e-04
-            gl0 = gl0 * x2 - 2.777777777777778e-03
-            gl0 = gl0 * x2 + 8.333333333333333e-02
-            gl = gl0/x0 + 0.5*log(xp) + (x0-0.5)*log(x0) - x0
-            if x <= 7.0
-                @simd for k in 1:n
-                    gl -= log(x0 - k)
-                end
-            end
-            return gl
-        end
-
-        @inline function hypergeometric_hyp(good, bad, sample)
-            d1 = bad + good - sample
-            d2 = min(bad, good)
-
-            Y = d2
-            K = sample
-            while Y > 0
-                Y -= floor(UInt, rand(rng) + Y/(d1 + K))
-                K -= 1
-                if K == 0
-                    break
-                end
-            end
-
-            Z = d2 - Y
-            return if good > bad
-                sample - Z
-            else
-                Z
-            end
-        end
-
-        @inline function hypergeometric_hrua(good, bad, sample)
-            mingoodbad = min(good, bad)
-            maxgoodbad = max(good, bad)
-            popsize = good + bad
-            m = min(sample, popsize - sample)
-            d4 = mingoodbad / popsize
-            d5 = 1.0 - d4
-            d6 = m*d4 + 0.5
-            d7 = sqrt((popsize - m) * sample * d4 * d5 / (popsize - 1) + 0.5)
-            # d8 = 2*sqrt(2/e) * d7 + (3 - 2*sqrt(3/e))
-            d8 = 1.7155277699214135*d7 + 0.8989161620588988
-            d9 = floor(UInt, (m + 1) * (mingoodbad + 1) / (popsize + 2))
-            d10 = (loggam(d9+1) + loggam(mingoodbad-d9+1) + loggam(m-d9+1) +
-                   loggam(maxgoodbad-m+d9+1))
-            d11 = min(m+1, mingoodbad+1, floor(UInt, d6+16*d7))
-
-            while true
-                X = rand(rng)
-                Y = rand(rng)
-                W = d6 + d8*(Y - 0.5)/X
-
-                (W < 0.0 || W >= d11) && continue
-                Z = floor(Int, W)
-                T = d10 - (loggam(Z+1) + loggam(mingoodbad-Z+1) + loggam(m-Z+1) +
-                           loggam(maxgoodbad-m+Z+1))
-                (X*(4.0-X)-3.0) <= T && break
-                (X*(X-T) >= 1) && continue
-                (2.0*log(X) <= T) && break
-            end
-
-            if good > bad
-                Z = m - Z
-            end
-
-            return if m < sample
-                good - Z
-            else
-                Z
-            end
-        end
-
-        return if sample > 10
-            hypergeometric_hrua(good, bad, sample)
+        Z = d2 - Y
+        return if good > bad
+            sample - Z
         else
-            hypergeometric_hyp(good, bad, sample)
+            Z
         end
     end
 
-    function check_input(
-            X                   :: AbstractMatrix{S},
-            Y                   :: AbstractVector{T},
-            W                   :: AbstractVector{U},
-            max_features        :: Int,
-            max_depth           :: Int,
-            min_samples_leaf    :: Int,
-            min_samples_split   :: Int,
-            min_purity_increase :: Float64) where {S, T, U}
-        n_samples, n_features = size(X)
-        if length(Y) != n_samples
-            throw("dimension mismatch between X and Y ($(size(X)) vs $(size(Y))")
-        elseif length(W) != n_samples
-            throw("dimension mismatch between X and W ($(size(X)) vs $(size(W))")
-        elseif max_depth < -1
-            throw("unexpected value for max_depth: $(max_depth) (expected:"
-                * " max_depth >= 0, or max_depth = -1 for infinite depth)")
-        elseif n_features < max_features
-            throw("number of features $(n_features) is less than the number "
-                * "of max features $(max_features)")
-        elseif max_features < 0
-            throw("number of features $(max_features) must be >= zero ")
-        elseif min_samples_leaf < 1
-            throw("min_samples_leaf must be a positive integer "
-                * "(given $(min_samples_leaf))")
-        elseif min_samples_split < 2
-            throw("min_samples_split must be at least 2 "
-                * "(given $(min_samples_split))")
+    @inline function hypergeometric_hrua(good, bad, sample)
+        mingoodbad = min(good, bad)
+        maxgoodbad = max(good, bad)
+        popsize = good + bad
+        m = min(sample, popsize - sample)
+        d4 = mingoodbad / popsize
+        d5 = 1.0 - d4
+        d6 = m * d4 + 0.5
+        d7 = sqrt((popsize - m) * sample * d4 * d5 / (popsize - 1) + 0.5)
+        # d8 = 2*sqrt(2/e) * d7 + (3 - 2*sqrt(3/e))
+        d8 = 1.7155277699214135 * d7 + 0.8989161620588988
+        d9 = floor(UInt, (m + 1) * (mingoodbad + 1) / (popsize + 2))
+        d10 = (
+            loggam(d9 + 1) +
+            loggam(mingoodbad - d9 + 1) +
+            loggam(m - d9 + 1) +
+            loggam(maxgoodbad - m + d9 + 1)
+        )
+        d11 = min(m + 1, mingoodbad + 1, floor(UInt, d6 + 16 * d7))
+
+        while true
+            X = rand(rng)
+            Y = rand(rng)
+            W = d6 + d8 * (Y - 0.5) / X
+
+            (W < 0.0 || W >= d11) && continue
+            Z = floor(Int, W)
+            T =
+                d10 - (
+                    loggam(Z + 1) +
+                    loggam(mingoodbad - Z + 1) +
+                    loggam(m - Z + 1) +
+                    loggam(maxgoodbad - m + Z + 1)
+                )
+            (X * (4.0 - X) - 3.0) <= T && break
+            (X * (X - T) >= 1) && continue
+            (2.0 * log(X) <= T) && break
+        end
+
+        if good > bad
+            Z = m - Z
+        end
+
+        return if m < sample
+            good - Z
+        else
+            Z
         end
     end
+
+    return if sample > 10
+        hypergeometric_hrua(good, bad, sample)
+    else
+        hypergeometric_hyp(good, bad, sample)
+    end
+end
+
+function check_input(
+    X::AbstractMatrix{S},
+    Y::AbstractVector{T},
+    W::AbstractVector{U},
+    max_features::Int,
+    max_depth::Int,
+    min_samples_leaf::Int,
+    min_samples_split::Int,
+    min_purity_increase::Float64,
+) where {S,T,U}
+    n_samples, n_features = size(X)
+    if length(Y) != n_samples
+        throw("dimension mismatch between X and Y ($(size(X)) vs $(size(Y))")
+    elseif length(W) != n_samples
+        throw("dimension mismatch between X and W ($(size(X)) vs $(size(W))")
+    elseif max_depth < -1
+        throw(
+            "unexpected value for max_depth: $(max_depth) (expected:" *
+            " max_depth >= 0, or max_depth = -1 for infinite depth)",
+        )
+    elseif n_features < max_features
+        throw(
+            "number of features $(n_features) is less than the number " *
+            "of max features $(max_features)",
+        )
+    elseif max_features < 0
+        throw("number of features $(max_features) must be >= zero ")
+    elseif min_samples_leaf < 1
+        throw(
+            "min_samples_leaf must be a positive integer " * "(given $(min_samples_leaf))"
+        )
+    elseif min_samples_split < 2
+        throw("min_samples_split must be at least 2 " * "(given $(min_samples_split))")
+    end
+end
 
 end

--- a/test/benchmark/classification_suite.jl
+++ b/test/benchmark/classification_suite.jl
@@ -1,13 +1,13 @@
 function benchmark_classification(build::Function, apply::Function)
     println("\nRunning benchmarks ...")
     ########## benchmarks suite ##########
-    suite                       = BenchmarkGroup()
-    suite["BUILD"]              = BenchmarkGroup()
-    suite["BUILD"]["DIGITS"]    = BenchmarkGroup()
-    suite["BUILD"]["ADULT"]     = BenchmarkGroup()
-    suite["APPLY"]              = BenchmarkGroup()
-    suite["APPLY"]["DIGITS"]    = BenchmarkGroup()
-    suite["APPLY"]["ADULT"]     = BenchmarkGroup()
+    suite = BenchmarkGroup()
+    suite["BUILD"] = BenchmarkGroup()
+    suite["BUILD"]["DIGITS"] = BenchmarkGroup()
+    suite["BUILD"]["ADULT"] = BenchmarkGroup()
+    suite["APPLY"] = BenchmarkGroup()
+    suite["APPLY"]["DIGITS"] = BenchmarkGroup()
+    suite["APPLY"]["ADULT"] = BenchmarkGroup()
 
     # using DIGITS dataset
     X, Y = load_data("digits")
@@ -15,24 +15,24 @@ function benchmark_classification(build::Function, apply::Function)
     m, n = size(X)
     X_Any = Array{Any}(undef, m, n)
     Y_Any = Array{Any}(undef, m)
-    X_Any[:,:] = X
-    Y_Any[:]   = Y
-    X_Any :: Matrix{Any}
-    Y_Any :: Vector{Any}
+    X_Any[:, :] = X
+    Y_Any[:] = Y
+    X_Any::Matrix{Any}
+    Y_Any::Vector{Any}
     model = build(Y_Any, X_Any)
     preds = apply(model, X_Any)
     suite["BUILD"]["DIGITS"][pad("Y::Any X::Any")] = @benchmarkable $build($Y_Any, $X_Any)
     suite["APPLY"]["DIGITS"][pad("Y::Any X::Any")] = @benchmarkable $apply($model, $X_Any)
 
-    X_Any         :: Matrix{Any}
-    Y = Int64.(Y) :: Vector{Int64}
+    X_Any::Matrix{Any}
+    Y = Int64.(Y)::Vector{Int64}
     model = build(Y, X_Any)
     preds = apply(model, X_Any)
     suite["BUILD"]["DIGITS"][pad("Y::Int64 X::Any")] = @benchmarkable $build($Y, $X_Any)
     suite["APPLY"]["DIGITS"][pad("Y::Int64 X::Any")] = @benchmarkable $apply($model, $X_Any)
 
-    X = Int64.(X) :: Matrix{Int64}
-    Y_Any         :: Vector{Any}
+    X = Int64.(X)::Matrix{Int64}
+    Y_Any::Vector{Any}
     model = build(Y_Any, X)
     preds = apply(model, X)
     suite["BUILD"]["DIGITS"][pad("Y::Any X::Int64")] = @benchmarkable $build($Y_Any, $X)
@@ -52,49 +52,49 @@ function benchmark_classification(build::Function, apply::Function)
     suite["BUILD"]["DIGITS"][pad("Y::Int64 X::Float64")] = @benchmarkable $build($Y, $X)
     suite["APPLY"]["DIGITS"][pad("Y::Int64 X::Float64")] = @benchmarkable $apply($model, $X)
 
-    Y = string.(Y) :: Vector{String}
+    Y = string.(Y)::Vector{String}
     X = Float64.(X)
     model = build(Y, X)
     preds = apply(model, X)
     suite["BUILD"]["DIGITS"][pad("Y::String X::Float64")] = @benchmarkable $build($Y, $X)
-    suite["APPLY"]["DIGITS"][pad("Y::String X::Float64")] = @benchmarkable $apply($model, $X)
-
+    suite["APPLY"]["DIGITS"][pad("Y::String X::Float64")] = @benchmarkable $apply(
+        $model, $X
+    )
 
     # using ADULT dataset
     X_Any, Y_Any = load_data("adult")
     n = round(Int, size(X_Any, 1))
 
-    Y_Any = Y_Any[1:n]   :: Vector{Any}
-    X_Any = X_Any[1:n, :]:: Matrix{Any}
+    Y_Any = Y_Any[1:n]::Vector{Any}
+    X_Any = X_Any[1:n, :]::Matrix{Any}
     model = build(Y_Any, X_Any)
     preds = apply(model, X_Any)
     suite["BUILD"]["ADULT"][pad("Y::Any X::Any")] = @benchmarkable $build($Y_Any, $X_Any)
     suite["APPLY"]["ADULT"][pad("Y::Any X::Any")] = @benchmarkable $apply($model, $X_Any)
 
-    Y = String.(Y_Any) :: Vector{String}
-    X_Any              :: Matrix{Any}
+    Y = String.(Y_Any)::Vector{String}
+    X_Any::Matrix{Any}
     model = build(Y, X_Any)
     preds = apply(model, X_Any)
     suite["BUILD"]["ADULT"][pad("Y::String X::Any")] = @benchmarkable $build($Y, $X_Any)
     suite["APPLY"]["ADULT"][pad("Y::String X::Any")] = @benchmarkable $apply($model, $X_Any)
 
-    Y_Any              :: Vector{Any}
-    X = string.(X_Any) :: Matrix{String}
+    Y_Any::Vector{Any}
+    X = string.(X_Any)::Matrix{String}
     model = build(Y_Any, X)
     preds = apply(model, X)
     suite["BUILD"]["ADULT"][pad("Y::Any X::String")] = @benchmarkable $build($Y_Any, $X)
     suite["APPLY"]["ADULT"][pad("Y::Any X::String")] = @benchmarkable $apply($model, $X)
 
-    Y = String.(Y) :: Vector{String}
-    X = String.(X) :: Matrix{String}
+    Y = String.(Y)::Vector{String}
+    X = String.(X)::Matrix{String}
     model = build(Y, X)
     preds = apply(model, X)
     suite["BUILD"]["ADULT"][pad("Y::String X::String")] = @benchmarkable $build($Y, $X)
     suite["APPLY"]["ADULT"][pad("Y::String X::String")] = @benchmarkable $apply($model, $X)
 
-
     ########## run suite ##########
     tune!(suite)
-    results = run(suite, verbose = true)
+    results = run(suite; verbose=true)
     return results
 end

--- a/test/benchmark/regression_suite.jl
+++ b/test/benchmark/regression_suite.jl
@@ -1,49 +1,52 @@
 function benchmark_regression(build::Function, apply::Function)
     println("\nRunning benchmarks ...")
     ########## benchmarks suite ##########
-    suite                       = BenchmarkGroup()
-    suite["BUILD"]              = BenchmarkGroup()
-    suite["BUILD"]["DIGITS"]    = BenchmarkGroup()
-    suite["APPLY"]              = BenchmarkGroup()
-    suite["APPLY"]["DIGITS"]    = BenchmarkGroup()
-    
+    suite = BenchmarkGroup()
+    suite["BUILD"] = BenchmarkGroup()
+    suite["BUILD"]["DIGITS"] = BenchmarkGroup()
+    suite["APPLY"] = BenchmarkGroup()
+    suite["APPLY"]["DIGITS"] = BenchmarkGroup()
+
     # using DIGITS dataset
     X, Y = load_data("digits")
 
     m, n = size(X)
     X_Any = Array{Any}(undef, m, n)
-    X_Any[:,:] = X
-    X_Any           :: Matrix{Any}
-    Y = Float64.(Y) :: Vector{Float64}
+    X_Any[:, :] = X
+    X_Any::Matrix{Any}
+    Y = Float64.(Y)::Vector{Float64}
     model = build(Y, X_Any)
     preds = apply(model, X_Any)
     suite["BUILD"]["DIGITS"][pad("Y::Float64 X::Any")] = @benchmarkable $build($Y, $X_Any)
-    suite["APPLY"]["DIGITS"][pad("Y::Float64 X::Any")] = @benchmarkable $apply($model, $X_Any)
+    suite["APPLY"]["DIGITS"][pad("Y::Float64 X::Any")] = @benchmarkable $apply(
+        $model, $X_Any
+    )
 
-    X = Int64.(X)   :: Matrix{Int64}
-    Y = Float64.(Y) :: Vector{Float64}
+    X = Int64.(X)::Matrix{Int64}
+    Y = Float64.(Y)::Vector{Float64}
     model = build(Y, X)
     preds = apply(model, X)
     suite["BUILD"]["DIGITS"][pad("Y::Float64 X::Int64")] = @benchmarkable $build($Y, $X)
     suite["APPLY"]["DIGITS"][pad("Y::Float64 X::Int64")] = @benchmarkable $apply($model, $X)
 
-    X = Int8.(X)   :: Matrix{Int8}
-    Y = Float16.(Y) :: Vector{Float16}
+    X = Int8.(X)::Matrix{Int8}
+    Y = Float16.(Y)::Vector{Float16}
     model = build(Y, X)
     preds = apply(model, X)
     suite["BUILD"]["DIGITS"][pad("Y::Float16 X::Int8")] = @benchmarkable $build($Y, $X)
     suite["APPLY"]["DIGITS"][pad("Y::Float16 X::Int8")] = @benchmarkable $apply($model, $X)
 
-    X = Float64.(X) :: Matrix{Float64}
-    Y = Float64.(Y) :: Vector{Float64}
+    X = Float64.(X)::Matrix{Float64}
+    Y = Float64.(Y)::Vector{Float64}
     model = build(Y, X)
     preds = apply(model, X)
     suite["BUILD"]["DIGITS"][pad("Y::Float64 X::Float64")] = @benchmarkable $build($Y, $X)
-    suite["APPLY"]["DIGITS"][pad("Y::Float64 X::Float64")] = @benchmarkable $apply($model, $X)
-
+    suite["APPLY"]["DIGITS"][pad("Y::Float64 X::Float64")] = @benchmarkable $apply(
+        $model, $X
+    )
 
     ########## run suite ##########
     tune!(suite)
-    results = run(suite, verbose = true)
+    results = run(suite; verbose=true)
     return results
 end

--- a/test/benchmark/utils.jl
+++ b/test/benchmark/utils.jl
@@ -11,7 +11,7 @@ end
 function pad(s::String, l::Int=21)
     t = length(s)
     p = max(0, l - t)
-    return s * " " ^ p
+    return s * " "^p
 end
 
 function print_details(results)
@@ -20,8 +20,8 @@ function print_details(results)
         s = "================ " * i * " ================"
         println("\n" * s)
         display(results[i])
-#        if typeof(results[i]) <: BenchmarkGroup
-#            print_details(results[i])
-#        end
+        #        if typeof(results[i]) <: BenchmarkGroup
+        #            print_details(results[i])
+        #        end
     end
 end

--- a/test/classification/adding_trees.jl
+++ b/test/classification/adding_trees.jl
@@ -1,7 +1,7 @@
 # determine order of a numerical list, eg, [0.3, 0.1, 0.6, -0.1] -> [3, 2, 4, 1]
 function rank(v)
-    w = sort(collect(enumerate(v)), by=last)
-    return first.(w) |> invperm
+    w = sort(collect(enumerate(v)); by=last)
+    return invperm(first.(w))
 end
 
 features, labels = load_data("iris")
@@ -10,7 +10,6 @@ labels = string.(labels)
 classes = unique(labels)
 
 @testset "adding models in an ensemble" begin
-
     n = 40   # n_trees in first step
     Δn = 30  # n_trees to be added
 
@@ -26,10 +25,9 @@ classes = unique(labels)
         apply_forest_proba(two_step_model[1:n], features, classes)
 
     # smoke test - predictions are from the classes seen:
-    @test issubset(unique(apply_forest(two_step_model, features)),  classes)
+    @test issubset(unique(apply_forest(two_step_model, features)), classes)
 
     # smoke test - one-step and two-step models predict the same feature rankings:
     @test rank(impurity_importance(one_step_model)) ==
         rank(impurity_importance(two_step_model))
-
 end

--- a/test/classification/adult.jl
+++ b/test/classification/adult.jl
@@ -2,59 +2,84 @@
 # https://archive.ics.uci.edu/ml/datasets/adult
 
 @testset "adult.jl" begin
+    features, labels = load_data("adult")
 
-features, labels = load_data("adult")
+    model = build_tree(labels, features; rng=StableRNG(1))
+    preds = apply_tree(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.99
 
-model = build_tree(labels, features; rng=StableRNG(1))
-preds = apply_tree(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.99
+    features = string.(features)
+    labels = string.(labels)
 
-features = string.(features)
-labels   = string.(labels)
+    n_subfeatures = 3
+    n_trees = 5
+    model = build_forest(labels, features, n_subfeatures, n_trees; rng=StableRNG(1))
+    preds = apply_forest(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.9
+    f1 = impurity_importance(model)
+    p1 =
+        permutation_importance(
+            model,
+            labels,
+            features,
+            (model, y, X) -> accuracy(y, apply_forest(model, X));
+            rng=StableRNG(1),
+        ).mean
 
-n_subfeatures = 3
-n_trees = 5
-model = build_forest(labels, features, n_subfeatures, n_trees; rng=StableRNG(1))
-preds = apply_forest(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.9
-f1 = impurity_importance(model)
-p1 = permutation_importance(model, labels, features, (model, y, X)->accuracy(y, apply_forest(model, X)), rng=StableRNG(1)).mean
+    preds_MT = apply_forest(model, features; use_multithreading=true)
+    cm_MT = confusion_matrix(labels, preds_MT)
+    @test cm_MT.accuracy > 0.9
 
-preds_MT = apply_forest(model, features, use_multithreading = true)
-cm_MT = confusion_matrix(labels, preds_MT)
-@test cm_MT.accuracy > 0.9
+    n_iterations = 15
+    model, coeffs = build_adaboost_stumps(labels, features, n_iterations; rng=StableRNG(1))
+    preds = apply_adaboost_stumps(model, coeffs, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.8
+    f2 = impurity_importance(model, coeffs)
+    p2 =
+        permutation_importance(
+            model,
+            labels,
+            features,
+            (model, y, X) -> accuracy(y, apply_forest(model, X));
+            rng=StableRNG(1),
+        ).mean
 
-n_iterations = 15
-model, coeffs = build_adaboost_stumps(labels, features, n_iterations; rng=StableRNG(1));
-preds = apply_adaboost_stumps(model, coeffs, features);
-cm = confusion_matrix(labels, preds);
-@test cm.accuracy > 0.8
-f2 = impurity_importance(model, coeffs)
-p2 = permutation_importance(model, labels, features, (model, y, X)->accuracy(y, apply_forest(model, X)), rng=StableRNG(1)).mean
+    @test similarity(p2, p2) > 0.8
+    @test similarity(f1, f2) < 0.8
 
-@test similarity(p2, p2) > 0.8
-@test similarity(f1, f2) < 0.8
+    println("\n##### 3 foldCV Classification Tree #####")
+    pruning_purity = 0.9
+    nfolds = 3
+    accuracy1 = nfoldCV_tree(
+        labels, features, nfolds, pruning_purity; rng=StableRNG(1), verbose=false
+    )
+    @test mean(accuracy1) > 0.8
 
-println("\n##### 3 foldCV Classification Tree #####")
-pruning_purity = 0.9
-nfolds = 3
-accuracy1 = nfoldCV_tree(labels, features, nfolds, pruning_purity; rng=StableRNG(1), verbose=false);
-@test mean(accuracy1) > 0.8
+    println("\n##### 3 foldCV Classification Forest #####")
+    n_subfeatures = 2
+    n_trees = 10
+    n_folds = 3
+    partial_sampling = 0.5
+    accuracy1 = nfoldCV_forest(
+        labels,
+        features,
+        n_folds,
+        n_subfeatures,
+        n_trees,
+        partial_sampling;
+        rng=StableRNG(1),
+        verbose=false,
+    )
+    @test mean(accuracy1) > 0.8
 
-println("\n##### 3 foldCV Classification Forest #####")
-n_subfeatures = 2
-n_trees = 10
-n_folds = 3
-partial_sampling = 0.5
-accuracy1 = nfoldCV_forest(labels, features, n_folds, n_subfeatures, n_trees, partial_sampling; rng=StableRNG(1), verbose=false)
-@test mean(accuracy1) > 0.8
-
-println("\n##### nfoldCV Classification Adaboosted Stumps #####")
-n_iterations = 15
-n_folds = 3
-accuracy1 = nfoldCV_stumps(labels, features, n_folds, n_iterations; rng=StableRNG(1), verbose=false);
-@test mean(accuracy1) > 0.8
-
+    println("\n##### nfoldCV Classification Adaboosted Stumps #####")
+    n_iterations = 15
+    n_folds = 3
+    accuracy1 = nfoldCV_stumps(
+        labels, features, n_folds, n_iterations; rng=StableRNG(1), verbose=false
+    )
+    @test mean(accuracy1) > 0.8
 end # @testset

--- a/test/classification/digits.jl
+++ b/test/classification/digits.jl
@@ -1,79 +1,83 @@
 @testset "digits.jl" begin
+    X, Y = load_data("digits")
 
-X, Y = load_data("digits")
+    t = DecisionTree.build_tree(Y, X)
+    @test length(t) == 148
+    @test sum(apply_tree(t, X) .== Y) == length(Y)
 
-t = DecisionTree.build_tree(Y, X)
-@test length(t) == 148
-@test sum(apply_tree(t, X) .== Y) == length(Y)
+    n_subfeatures = 0
+    max_depth = 6
+    min_samples_leaf = 5
+    t = DecisionTree.build_tree(Y, X, n_subfeatures, max_depth)
+    @test length(t) == 57
 
+    t = DecisionTree.build_tree(Y, X, n_subfeatures, max_depth, min_samples_leaf)
+    @test length(t) == 50
 
-n_subfeatures       = 0
-max_depth           = 6
-min_samples_leaf    = 5
-t = DecisionTree.build_tree(
-        Y, X,
-        n_subfeatures, max_depth)
-@test length(t) == 57
+    min_samples_leaf = 3
+    min_samples_split = 5
+    min_purity_increase = 0.05
+    t = DecisionTree.build_tree(
+        Y, X, n_subfeatures, max_depth, min_samples_leaf, min_samples_split
+    )
+    @test length(t) == 55
 
-t = DecisionTree.build_tree(
-        Y, X,
-        n_subfeatures, max_depth,
-        min_samples_leaf)
-@test length(t) == 50
-
-min_samples_leaf    = 3
-min_samples_split   = 5
-min_purity_increase = 0.05
-t = DecisionTree.build_tree(
-        Y, X,
-        n_subfeatures, max_depth,
-        min_samples_leaf,
-        min_samples_split)
-@test length(t) == 55
-
-t = DecisionTree.build_tree(
-        Y, X,
-        n_subfeatures, max_depth,
+    t = DecisionTree.build_tree(
+        Y,
+        X,
+        n_subfeatures,
+        max_depth,
         min_samples_leaf,
         min_samples_split,
-        min_purity_increase,
-        rng=StableRNG(1))
-@test length(t) == 54
-i1 = impurity_importance(t, normalize = true)
-s1 = split_importance(t)
-p1 = permutation_importance(t, Y, X, (model, y, X)->accuracy(y, apply_tree(model, X)), rng=StableRNG(1)).mean
+        min_purity_increase;
+        rng=StableRNG(1),
+    )
+    @test length(t) == 54
+    i1 = impurity_importance(t; normalize=true)
+    s1 = split_importance(t)
+    p1 =
+        permutation_importance(
+            t, Y, X, (model, y, X) -> accuracy(y, apply_tree(model, X)); rng=StableRNG(1)
+        ).mean
 
-# test that all purity decisions are based on passed-in purity function;
-# if so, this should be same as previous test
-entropy1000(ns, n) = DecisionTree.util.entropy(ns, n) * 1000
-min_samples_leaf    = 3
-min_samples_split   = 5
-min_purity_increase = 0.05 * 1000
-t = DecisionTree.build_tree(
-        Y, X,
-        n_subfeatures, max_depth,
+    # test that all purity decisions are based on passed-in purity function;
+    # if so, this should be same as previous test
+    entropy1000(ns, n) = DecisionTree.util.entropy(ns, n) * 1000
+    min_samples_leaf = 3
+    min_samples_split = 5
+    min_purity_increase = 0.05 * 1000
+    t = DecisionTree.build_tree(
+        Y,
+        X,
+        n_subfeatures,
+        max_depth,
         min_samples_leaf,
         min_samples_split,
-        min_purity_increase,
-        loss = entropy1000,
-        rng=StableRNG(1))
-@test length(t) == 54
-i2 = impurity_importance(t, normalize = true)
-s2 = split_importance(t)
-p2 = permutation_importance(t, Y, X, (model, y, X)->accuracy(y, apply_tree(model, X)), rng=StableRNG(1)).mean
-@test isapprox(i2, i1)
-@test s1 == s2
-@test similarity(p2, p1) > 0.9
+        min_purity_increase;
+        loss=entropy1000,
+        rng=StableRNG(1),
+    )
+    @test length(t) == 54
+    i2 = impurity_importance(t; normalize=true)
+    s2 = split_importance(t)
+    p2 =
+        permutation_importance(
+            t, Y, X, (model, y, X) -> accuracy(y, apply_tree(model, X)); rng=StableRNG(1)
+        ).mean
+    @test isapprox(i2, i1)
+    @test s1 == s2
+    @test similarity(p2, p1) > 0.9
 
-n_subfeatures       = 3
-n_trees             = 10
-partial_sampling    = 0.7
-max_depth           = -1
-min_samples_leaf    = 1
-min_samples_split   = 2
-min_purity_increase = 0.0
-model = DecisionTree.build_forest(
-        Y, X,
+    n_subfeatures = 3
+    n_trees = 10
+    partial_sampling = 0.7
+    max_depth = -1
+    min_samples_leaf = 1
+    min_samples_split = 2
+    min_purity_increase = 0.0
+    model = DecisionTree.build_forest(
+        Y,
+        X,
         n_subfeatures,
         n_trees,
         partial_sampling,
@@ -81,21 +85,19 @@ model = DecisionTree.build_forest(
         min_samples_leaf,
         min_samples_split,
         min_purity_increase;
-        rng=StableRNG(1))
-preds = apply_forest(model, X)
-cm = confusion_matrix(Y, preds)
-@test cm.accuracy > 0.95
+        rng=StableRNG(1),
+    )
+    preds = apply_forest(model, X)
+    cm = confusion_matrix(Y, preds)
+    @test cm.accuracy > 0.95
 
-preds_MT = apply_forest(model, X, use_multithreading = true)
-cm_MT = confusion_matrix(Y, preds_MT)
-@test cm_MT.accuracy > 0.95
+    preds_MT = apply_forest(model, X; use_multithreading=true)
+    cm_MT = confusion_matrix(Y, preds_MT)
+    @test cm_MT.accuracy > 0.95
 
-n_iterations        = 100
-model, coeffs = DecisionTree.build_adaboost_stumps(
-        Y, X,
-        n_iterations);
-preds = apply_adaboost_stumps(model, coeffs, X);
-cm = confusion_matrix(Y, preds)
-@test cm.accuracy > 0.8
-
+    n_iterations = 100
+    model, coeffs = DecisionTree.build_adaboost_stumps(Y, X, n_iterations)
+    preds = apply_adaboost_stumps(model, coeffs, X)
+    cm = confusion_matrix(Y, preds)
+    @test cm.accuracy > 0.8
 end # @testset

--- a/test/classification/heterogeneous.jl
+++ b/test/classification/heterogeneous.jl
@@ -1,39 +1,37 @@
 ### Classification - Heterogeneously typed features (ints, floats, bools, strings)
 
 @testset "heterogeneous.jl" begin
+    m, n = 10^2, 5
 
-m, n = 10^2, 5
+    tf = [trues(Int(m / 2)) falses(Int(m / 2))]
+    inds = Random.randperm(StableRNG(1), m)
+    labels = string.(tf[inds])
 
-tf = [trues(Int(m/2)) falses(Int(m/2))]
-inds = Random.randperm(StableRNG(1), m)
-labels = string.(tf[inds])
+    features = Array{Any}(undef, m, n)
+    features[:, :] = randn(StableRNG(1), m, n)
+    features[:, 2] = string.(tf[Random.randperm(StableRNG(1), m)])
+    features[:, 3] = map(t -> round.(Int, t), features[:, 3])
+    features[:, 4] = tf[inds]
 
-features = Array{Any}(undef, m, n)
-features[:,:] = randn(StableRNG(1), m, n)
-features[:,2] = string.(tf[Random.randperm(StableRNG(1), m)])
-features[:,3] = map(t -> round.(Int, t), features[:,3])
-features[:,4] = tf[inds]
+    model = build_tree(labels, features; rng=StableRNG(1))
+    preds = apply_tree(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.9
 
-model = build_tree(labels, features; rng=StableRNG(1))
-preds = apply_tree(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.9
+    n_subfeatures = 2
+    n_trees = 3
+    model = build_forest(labels, features, n_subfeatures, n_trees; rng=StableRNG(1))
+    preds = apply_forest(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.9
 
-n_subfeatures = 2
-n_trees = 3
-model = build_forest(labels, features, n_subfeatures, n_trees; rng=StableRNG(1))
-preds = apply_forest(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.9
+    preds_MT = apply_forest(model, features; use_multithreading=true)
+    cm_MT = confusion_matrix(labels, preds_MT)
+    @test cm_MT.accuracy > 0.9
 
-preds_MT = apply_forest(model, features, use_multithreading = true)
-cm_MT = confusion_matrix(labels, preds_MT)
-@test cm_MT.accuracy > 0.9
-
-n_subfeatures = 7
-model, coeffs = build_adaboost_stumps(labels, features, n_subfeatures; rng=StableRNG(1))
-preds = apply_adaboost_stumps(model, coeffs, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.9
-
+    n_subfeatures = 7
+    model, coeffs = build_adaboost_stumps(labels, features, n_subfeatures; rng=StableRNG(1))
+    preds = apply_adaboost_stumps(model, coeffs, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.9
 end # @testset

--- a/test/classification/iris.jl
+++ b/test/classification/iris.jl
@@ -2,113 +2,115 @@
 # https://archive.ics.uci.edu/ml/datasets/iris
 
 @testset "iris.jl" begin
+    features, labels = load_data("iris")
+    labels = String.(labels)
+    classes = sort(unique(labels))
+    n = length(labels)
 
-features, labels = load_data("iris")
-labels = String.(labels)
-classes = sort(unique(labels))
-n = length(labels)
+    # train a decision stump (depth=1)
+    model = build_stump(labels, features)
+    preds = apply_tree(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.6
+    @test depth(model) == 1
+    probs = apply_tree_proba(model, features, classes)
+    @test reshape(sum(probs; dims=2), n) ≈ ones(n)
 
-# train a decision stump (depth=1)
-model = build_stump(labels, features)
-preds = apply_tree(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.6
-@test depth(model) == 1
-probs = apply_tree_proba(model, features, classes)
-@test reshape(sum(probs, dims=2), n) ≈ ones(n)
+    # train full-tree classifier (over-fit)
+    model = build_tree(labels, features)
+    preds = apply_tree(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy == 1.0
+    @test length(model) == 9
+    @test depth(model) == 5
+    @test typeof(preds) == Vector{String}
+    print_tree(model)
+    probs = apply_tree_proba(model, features, classes)
+    @test reshape(sum(probs; dims=2), n) ≈ ones(n)
+    i1 = impurity_importance(model)
+    s1 = split_importance(model)
 
-# train full-tree classifier (over-fit)
-model = build_tree(labels, features)
-preds = apply_tree(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy == 1.0
-@test length(model) == 9
-@test depth(model) == 5
-@test typeof(preds) == Vector{String}
-print_tree(model)
-probs = apply_tree_proba(model, features, classes)
-@test reshape(sum(probs, dims=2), n) ≈ ones(n)
-i1 = impurity_importance(model)
-s1 = split_importance(model)
+    # prune tree to 8 leaves
+    pruning_purity = 0.9
+    pt = prune_tree(model, pruning_purity)
+    @test length(pt) == 8
+    preds = apply_tree(pt, features)
+    cm = confusion_matrix(labels, preds)
+    @test 0.99 < cm.accuracy < 1.0
+    i2 = impurity_importance(pt)
+    s2 = split_importance(pt)
+    @test isapprox(i2, i1 .+ [0, 0, 0, (47 * log(47 / 48) + log(1 / 48)) / 150])
+    @test s1 == s2 .+ [0, 0, 0, 1]
 
-# prune tree to 8 leaves
-pruning_purity = 0.9
-pt = prune_tree(model, pruning_purity)
-@test length(pt) == 8
-preds = apply_tree(pt, features)
-cm = confusion_matrix(labels, preds)
-@test 0.99 < cm.accuracy < 1.0
-i2 = impurity_importance(pt)
-s2 = split_importance(pt)
-@test isapprox(i2, i1.+ [0, 0, 0, (47*log(47/48) + log(1/48))/150])
-@test s1 == s2 .+ [0, 0, 0, 1]
+    # prune tree to 3 leaves
+    pruning_purity = 0.6
+    pt = prune_tree(model, pruning_purity)
+    @test length(pt) == 3
+    preds = apply_tree(pt, features)
+    cm = confusion_matrix(labels, preds)
+    @test 0.95 < cm.accuracy < 1.0
+    probs = apply_tree_proba(model, features, classes)
+    @test reshape(sum(probs; dims=2), n) ≈ ones(n)
 
-# prune tree to 3 leaves
-pruning_purity = 0.6
-pt = prune_tree(model, pruning_purity)
-@test length(pt) == 3
-preds = apply_tree(pt, features)
-cm = confusion_matrix(labels, preds)
-@test 0.95 < cm.accuracy < 1.0
-probs = apply_tree_proba(model, features, classes)
-@test reshape(sum(probs, dims=2), n) ≈ ones(n)
+    # prune tree to a stump, 2 leaves
+    pruning_purity = 0.5
+    pt = prune_tree(model, pruning_purity)
+    @test length(pt) == 2
+    preds = apply_tree(pt, features)
+    cm = confusion_matrix(labels, preds)
+    @test 0.66 < cm.accuracy < 1.0
 
-# prune tree to a stump, 2 leaves
-pruning_purity = 0.5
-pt = prune_tree(model, pruning_purity)
-@test length(pt) == 2
-preds = apply_tree(pt, features)
-cm = confusion_matrix(labels, preds)
-@test 0.66 < cm.accuracy < 1.0
+    # run n-fold cross validation for pruned tree
+    println("\n##### nfoldCV Classification Tree #####")
+    nfolds = 3
+    accuracy = nfoldCV_tree(labels, features, nfolds; rng=StableRNG(1))
+    @test mean(accuracy) > 0.8
 
-# run n-fold cross validation for pruned tree
-println("\n##### nfoldCV Classification Tree #####")
-nfolds = 3
-accuracy = nfoldCV_tree(labels, features, nfolds; rng=StableRNG(1))
-@test mean(accuracy) > 0.8
+    # train random forest classifier
+    n_trees = 10
+    n_subfeatures = 2
+    partial_sampling = 0.5
+    model = build_forest(
+        labels, features, n_subfeatures, n_trees, partial_sampling; rng=StableRNG(2)
+    )
+    preds = apply_forest(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.95
+    @test typeof(preds) == Vector{String}
+    probs = apply_forest_proba(model, features, classes)
+    @test reshape(sum(probs; dims=2), n) ≈ ones(n)
 
-# train random forest classifier
-n_trees = 10
-n_subfeatures = 2
-partial_sampling = 0.5
-model = build_forest(labels, features, n_subfeatures, n_trees, partial_sampling; rng=StableRNG(2))
-preds = apply_forest(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.95
-@test typeof(preds) == Vector{String}
-probs = apply_forest_proba(model, features, classes)
-@test reshape(sum(probs, dims=2), n) ≈ ones(n)
+    preds_MT = apply_forest(model, features; use_multithreading=true)
+    cm_MT = confusion_matrix(labels, preds_MT)
+    @test cm_MT.accuracy > 0.95
+    @test typeof(preds_MT) == Vector{String}
+    @test sum(preds .!= preds_MT) == 0
 
-preds_MT = apply_forest(model, features, use_multithreading = true)
-cm_MT = confusion_matrix(labels, preds_MT)
-@test cm_MT.accuracy > 0.95
-@test typeof(preds_MT) == Vector{String}
-@test sum(preds .!= preds_MT) == 0
+    # run n-fold cross validation for forests
+    println("\n##### nfoldCV Classification Forest #####")
+    n_subfeatures = 2
+    n_trees = 10
+    n_folds = 3
+    partial_sampling = 0.5
+    accuracy = nfoldCV_forest(
+        labels, features, nfolds, n_subfeatures, n_trees, partial_sampling; rng=StableRNG(1)
+    )
+    @test mean(accuracy) > 0.9
 
-# run n-fold cross validation for forests
-println("\n##### nfoldCV Classification Forest #####")
-n_subfeatures = 2
-n_trees = 10
-n_folds = 3
-partial_sampling = 0.5
-accuracy = nfoldCV_forest(labels, features, nfolds, n_subfeatures, n_trees, partial_sampling; rng=StableRNG(1))
-@test mean(accuracy) > 0.9
+    # train adaptive-boosted decision stumps
+    n_iterations = 15
+    model, coeffs = build_adaboost_stumps(labels, features, n_iterations; rng=StableRNG(1))
+    preds = apply_adaboost_stumps(model, coeffs, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.9
+    @test typeof(preds) == Vector{String}
+    probs = apply_adaboost_stumps_proba(model, coeffs, features, classes)
+    @test reshape(sum(probs; dims=2), n) ≈ ones(n)
 
-# train adaptive-boosted decision stumps
-n_iterations = 15
-model, coeffs = build_adaboost_stumps(labels, features, n_iterations; rng=StableRNG(1))
-preds = apply_adaboost_stumps(model, coeffs, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.9
-@test typeof(preds) == Vector{String}
-probs = apply_adaboost_stumps_proba(model, coeffs, features, classes)
-@test reshape(sum(probs, dims=2), n) ≈ ones(n)
-
-# run n-fold cross validation for boosted stumps, using 7 iterations and 3 folds
-println("\n##### nfoldCV Classification Adaboosted Stumps #####")
-n_iterations = 15
-nfolds = 3
-accuracy = nfoldCV_stumps(labels, features, nfolds, n_iterations; rng=StableRNG(1))
-@test mean(accuracy) > 0.85
-
+    # run n-fold cross validation for boosted stumps, using 7 iterations and 3 folds
+    println("\n##### nfoldCV Classification Adaboosted Stumps #####")
+    n_iterations = 15
+    nfolds = 3
+    accuracy = nfoldCV_stumps(labels, features, nfolds, n_iterations; rng=StableRNG(1))
+    @test mean(accuracy) > 0.85
 end # @testset

--- a/test/classification/random.jl
+++ b/test/classification/random.jl
@@ -1,75 +1,74 @@
 
 @testset "random.jl" begin
+    Random.seed!(16)
 
-Random.seed!(16)
+    n, m = 10^3, 5
+    features = rand(StableRNG(1), n, m)
+    weights = rand(StableRNG(1), -1:1, m)
+    labels = round.(Int, features * weights)
 
-n, m = 10^3, 5;
-features = rand(StableRNG(1), n, m);
-weights = rand(StableRNG(1), -1:1, m);
-labels = round.(Int, features * weights);
+    model = build_stump(labels, round.(Int, features))
+    preds = apply_tree(model, round.(Int, features))
+    @test depth(model) == 1
 
-model = build_stump(labels, round.(Int, features))
-preds = apply_tree(model, round.(Int, features))
-@test depth(model) == 1
+    max_depth = 3
+    model = build_tree(labels, features, 0, max_depth)
+    @test depth(model) == max_depth
 
-max_depth = 3
-model = build_tree(labels, features, 0, max_depth)
-@test depth(model) == max_depth
+    io = IOBuffer()
+    print_tree(io, model, 3)
+    text = String(take!(io))
+    println()
+    print(text)
+    println()
 
-io = IOBuffer()
-print_tree(io, model, 3)
-text = String(take!(io))
-println()
-print(text)
-println()
+    # Read the regex as: many not arrow left followed by an arrow left, a space, some numbers and
+    # a dot and a space and question mark.
+    rx = r"[^<]*< [0-9\.]* ?"
+    matches = eachmatch(rx, text)
+    @test !isempty(matches)
 
-# Read the regex as: many not arrow left followed by an arrow left, a space, some numbers and
-# a dot and a space and question mark.
-rx = r"[^<]*< [0-9\.]* ?"
-matches = eachmatch(rx, text)
-@test !isempty(matches)
+    model = build_tree(labels, features; rng=StableRNG(1))
+    preds = apply_tree(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.9
+    @test typeof(preds) == Vector{Int}
 
-model = build_tree(labels, features; rng=StableRNG(1))
-preds = apply_tree(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.9
-@test typeof(preds) == Vector{Int}
+    # test RNG param of trees
+    n_subfeatures = 2
+    t1 = build_tree(labels, features, n_subfeatures; rng=10)
+    t2 = build_tree(labels, features, n_subfeatures; rng=10)
+    t3 = build_tree(labels, features, n_subfeatures; rng=5)
+    @test (length(t1) == length(t2)) && (depth(t1) == depth(t2))
+    @test (length(t1) != length(t3)) || (depth(t1) != depth(t3))
 
-# test RNG param of trees
-n_subfeatures = 2
-t1 = build_tree(labels, features, n_subfeatures; rng=10)
-t2 = build_tree(labels, features, n_subfeatures; rng=10)
-t3 = build_tree(labels, features, n_subfeatures; rng=5)
-@test (length(t1) == length(t2)) && (depth(t1) == depth(t2))
-@test (length(t1) != length(t3)) || (depth(t1) != depth(t3))
+    mt = Random.MersenneTwister(1)
+    t1 = build_tree(labels, features, n_subfeatures; rng=mt)
+    t3 = build_tree(labels, features, n_subfeatures; rng=mt)
+    @test (length(t1) != length(t3)) || (depth(t1) != depth(t3))
 
-mt = Random.MersenneTwister(1)
-t1 = build_tree(labels, features, n_subfeatures; rng=mt)
-t3 = build_tree(labels, features, n_subfeatures; rng=mt)
-@test (length(t1) != length(t3)) || (depth(t1) != depth(t3))
+    model = build_forest(labels, features; rng=StableRNG(1))
+    preds = apply_forest(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.9
+    @test typeof(preds) == Vector{Int}
 
+    preds_MT = apply_forest(model, features; use_multithreading=true)
+    cm_MT = confusion_matrix(labels, preds_MT)
+    @test cm_MT.accuracy > 0.9
+    @test typeof(preds_MT) == Vector{Int}
+    @test sum(abs.(preds .- preds_MT)) == zero(Int)
 
-model = build_forest(labels, features; rng=StableRNG(1))
-preds = apply_forest(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.9
-@test typeof(preds) == Vector{Int}
-
-preds_MT = apply_forest(model, features, use_multithreading = true)
-cm_MT = confusion_matrix(labels, preds_MT)
-@test cm_MT.accuracy > 0.9
-@test typeof(preds_MT) == Vector{Int}
-@test sum(abs.(preds .- preds_MT)) == zero(Int)
-
-n_subfeatures       = 3
-n_trees             = 9
-partial_sampling    = 0.7
-max_depth           = -1
-min_samples_leaf    = 5
-min_samples_split   = 2
-min_purity_increase = 0.0
-model = build_forest(
-        labels, features,
+    n_subfeatures = 3
+    n_trees = 9
+    partial_sampling = 0.7
+    max_depth = -1
+    min_samples_leaf = 5
+    min_samples_split = 2
+    min_purity_increase = 0.0
+    model = build_forest(
+        labels,
+        features,
         n_subfeatures,
         n_trees,
         partial_sampling,
@@ -77,110 +76,102 @@ model = build_forest(
         min_samples_leaf,
         min_samples_split,
         min_purity_increase;
-        rng=StableRNG(1))
-preds = apply_forest(model, features)
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.6
-@test length(model) == n_trees
+        rng=StableRNG(1),
+    )
+    preds = apply_forest(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.6
+    @test length(model) == n_trees
 
-preds_MT = apply_forest(model, features, use_multithreading = true)
-cm_MT = confusion_matrix(labels, preds_MT)
-@test cm_MT.accuracy > 0.9
+    preds_MT = apply_forest(model, features; use_multithreading=true)
+    cm_MT = confusion_matrix(labels, preds_MT)
+    @test cm_MT.accuracy > 0.9
 
-# test n_subfeatures
-n_subfeatures       = 0
-m_partial = build_forest(labels, features; rng=StableRNG(1)) # default sqrt(n_features)
-m_full    = build_forest(labels, features, n_subfeatures; rng=StableRNG(1))
-@test all( length.(m_full.trees) .< length.(m_partial.trees) )
+    # test n_subfeatures
+    n_subfeatures = 0
+    m_partial = build_forest(labels, features; rng=StableRNG(1)) # default sqrt(n_features)
+    m_full = build_forest(labels, features, n_subfeatures; rng=StableRNG(1))
+    @test all(length.(m_full.trees) .< length.(m_partial.trees))
 
-# test partial_sampling parameter, train on single sample
-partial_sampling    = 1 / n
-n_subfeatures       = 0
-n_trees             = 1         # single tree test
-max_depth           = -1
-min_samples_leaf    = 1
-min_samples_split   = 2
-min_purity_increase = 0.0
-partial = build_forest(
-            labels, features,
-            n_subfeatures,
-            n_trees,
-            partial_sampling,
-            max_depth,
-            min_samples_leaf,
-            min_samples_split,
-            min_purity_increase)
-@test typeof(partial.trees[1]) <: Leaf
-
-# test RNG parameter for forests
-n_subfeatures       = 2
-n_trees             = 5
-m1 = build_forest(labels, features,
+    # test partial_sampling parameter, train on single sample
+    partial_sampling = 1 / n
+    n_subfeatures = 0
+    n_trees = 1         # single tree test
+    max_depth = -1
+    min_samples_leaf = 1
+    min_samples_split = 2
+    min_purity_increase = 0.0
+    partial = build_forest(
+        labels,
+        features,
         n_subfeatures,
-        n_trees;
-        rng=10)
-m2 = build_forest(labels, features,
-        n_subfeatures,
-        n_trees;
-        rng=10)
-m3 = build_forest(labels, features,
-        n_subfeatures,
-        n_trees;
-        rng=5)
-@test length.(m1.trees) == length.(m2.trees)
-@test depth.(m1.trees)  == depth.(m2.trees)
-@test length.(m1.trees) != length.(m3.trees)
+        n_trees,
+        partial_sampling,
+        max_depth,
+        min_samples_leaf,
+        min_samples_split,
+        min_purity_increase,
+    )
+    @test typeof(partial.trees[1]) <: Leaf
 
+    # test RNG parameter for forests
+    n_subfeatures = 2
+    n_trees = 5
+    m1 = build_forest(labels, features, n_subfeatures, n_trees; rng=10)
+    m2 = build_forest(labels, features, n_subfeatures, n_trees; rng=10)
+    m3 = build_forest(labels, features, n_subfeatures, n_trees; rng=5)
+    @test length.(m1.trees) == length.(m2.trees)
+    @test depth.(m1.trees) == depth.(m2.trees)
+    @test length.(m1.trees) != length.(m3.trees)
 
-n_iterations = 25
-model, coeffs = build_adaboost_stumps(labels, features, n_iterations; rng=StableRNG(1));
-preds = apply_adaboost_stumps(model, coeffs, features);
-cm = confusion_matrix(labels, preds)
-@test cm.accuracy > 0.6
-@test typeof(preds) == Vector{Int}
-@test length(model) == n_iterations
+    n_iterations = 25
+    model, coeffs = build_adaboost_stumps(labels, features, n_iterations; rng=StableRNG(1))
+    preds = apply_adaboost_stumps(model, coeffs, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.6
+    @test typeof(preds) == Vector{Int}
+    @test length(model) == n_iterations
 
-"""
-RNGs can look like they produce stable results, but do in fact differ when you run it many times.
-In some RNGs the problem already shows up when doing two runs and comparing those.
-This loop tests multiple RNGs to have a higher chance of spotting a problem.
-See https://github.com/JuliaAI/DecisionTree.jl/pull/174 for more information.
-"""
-function test_rng(f::Function, args, expected_accuracy)
-    println("Testing $f")
-    accuracy = f(args...; rng=StableRNG(10), verbose=false)
-    accuracy2 = f(args...; rng=StableRNG(5), verbose=false)
-    @test accuracy != accuracy2
+    """
+    RNGs can look like they produce stable results, but do in fact differ when you run it many times.
+    In some RNGs the problem already shows up when doing two runs and comparing those.
+    This loop tests multiple RNGs to have a higher chance of spotting a problem.
+    See https://github.com/JuliaAI/DecisionTree.jl/pull/174 for more information.
+    """
+    function test_rng(f::Function, args, expected_accuracy)
+        println("Testing $f")
+        accuracy = f(args...; rng=StableRNG(10), verbose=false)
+        accuracy2 = f(args...; rng=StableRNG(5), verbose=false)
+        @test accuracy != accuracy2
 
-    for i in 10:14
-        accuracy  = f(args...; rng=StableRNG(i), verbose=false)
-        accuracy2 = f(args...; rng=StableRNG(i), verbose=false)
-        @test mean(accuracy) > expected_accuracy
-        @test accuracy == accuracy2
+        for i in 10:14
+            accuracy = f(args...; rng=StableRNG(i), verbose=false)
+            accuracy2 = f(args...; rng=StableRNG(i), verbose=false)
+            @test mean(accuracy) > expected_accuracy
+            @test accuracy == accuracy2
+        end
     end
-end
 
-println("\n##### nfoldCV Classification Tree #####")
-nfolds          = 3
-pruning_purity  = 1.0
-max_depth       = 5
-args = [labels, features, nfolds, pruning_purity, max_depth]
-test_rng(nfoldCV_tree, args, 0.7)
+    println("\n##### nfoldCV Classification Tree #####")
+    nfolds = 3
+    pruning_purity = 1.0
+    max_depth = 5
+    args = [labels, features, nfolds, pruning_purity, max_depth]
+    test_rng(nfoldCV_tree, args, 0.7)
 
-println("\n##### nfoldCV Classification Forest #####")
-nfolds          = 3
-n_subfeatures   = 2
-n_trees         = 10
-args = [labels, features, nfolds, n_subfeatures, n_trees]
-test_rng(nfoldCV_forest, args, 0.7)
+    println("\n##### nfoldCV Classification Forest #####")
+    nfolds = 3
+    n_subfeatures = 2
+    n_trees = 10
+    args = [labels, features, nfolds, n_subfeatures, n_trees]
+    test_rng(nfoldCV_forest, args, 0.7)
 
-# This is a smoke test to verify that the multi-threaded code doesn't crash.
-nfoldCV_forest(args...; rng=MersenneTwister(1))
+    # This is a smoke test to verify that the multi-threaded code doesn't crash.
+    nfoldCV_forest(args...; rng=MersenneTwister(1))
 
-println("\n##### nfoldCV Adaboosted Stumps #####")
-n_iterations = 25
-n_folds = 3
-args = [labels, features, n_folds, n_iterations]
-test_rng(nfoldCV_stumps, args, 0.6)
-
+    println("\n##### nfoldCV Adaboosted Stumps #####")
+    n_iterations = 25
+    n_folds = 3
+    args = [labels, features, n_folds, n_iterations]
+    test_rng(nfoldCV_stumps, args, 0.6)
 end # @testset

--- a/test/classification/scikitlearn.jl
+++ b/test/classification/scikitlearn.jl
@@ -1,49 +1,77 @@
 @testset "scikitlearn.jl" begin
+    Random.seed!(2)
+    n, m = 10^3, 5
+    features = rand(StableRNG(1), n, m)
+    weights = rand(StableRNG(1), -1:1, m)
+    labels = round.(Int, features * weights)
 
-Random.seed!(2)
-n, m = 10^3, 5;
-features = rand(StableRNG(1), n, m);
-weights = rand(StableRNG(1), -1:1, m);
-labels = round.(Int, features * weights);
+    # I wish we could use ScikitLearn.jl's cross-validation, but that'd require
+    # installing it on Travis
+    model = fit!(
+        DecisionTreeClassifier(; rng=StableRNG(1), pruning_purity_threshold=0.9),
+        features,
+        labels,
+    )
+    @test mean(predict(model, features) .== labels) > 0.8
+    @test impurity_importance(model) == impurity_importance(model.root)
+    @test split_importance(model) == split_importance(model.root)
+    @test isapprox(
+        permutation_importance(model, features, labels; rng=StableRNG(1)).mean,
+        permutation_importance(
+            model.root,
+            labels,
+            features,
+            (model, y, X) -> accuracy(y, apply_tree(model, X));
+            rng=StableRNG(1),
+        ).mean,
+    )
 
-# I wish we could use ScikitLearn.jl's cross-validation, but that'd require
-# installing it on Travis
-model = fit!(DecisionTreeClassifier(; rng=StableRNG(1), pruning_purity_threshold=0.9), features, labels)
-@test mean(predict(model, features) .== labels) > 0.8
-@test impurity_importance(model) == impurity_importance(model.root)
-@test split_importance(model) == split_importance(model.root)
-@test isapprox(permutation_importance(model, features, labels, rng=StableRNG(1)).mean, permutation_importance(model.root, labels, features, (model, y, X) -> accuracy(y, apply_tree(model, X)), rng=StableRNG(1)).mean)
+    model = fit!(RandomForestClassifier(; rng=StableRNG(1)), features, labels)
+    @test mean(predict(model, features) .== labels) > 0.8
+    @test impurity_importance(model) == impurity_importance(model.ensemble)
+    @test split_importance(model) == split_importance(model.ensemble)
+    @test isapprox(
+        permutation_importance(model, features, labels; rng=StableRNG(1)).mean,
+        permutation_importance(
+            model.ensemble,
+            labels,
+            features,
+            (model, y, X) -> accuracy(y, apply_forest(model, X));
+            rng=StableRNG(1),
+        ).mean,
+    )
 
-model = fit!(RandomForestClassifier(; rng=StableRNG(1)), features, labels)
-@test mean(predict(model, features) .== labels) > 0.8
-@test impurity_importance(model) == impurity_importance(model.ensemble)
-@test split_importance(model) == split_importance(model.ensemble)
-@test isapprox(permutation_importance(model, features, labels, rng=StableRNG(1)).mean, permutation_importance(model.ensemble, labels, features, (model, y, X) -> accuracy(y, apply_forest(model, X)), rng=StableRNG(1)).mean)
+    model = fit!(AdaBoostStumpClassifier(; rng=StableRNG(1)), features, labels)
+    # Adaboost isn't so hot on this task, disabled for now
+    mean(predict(model, features) .== labels)
+    @test impurity_importance(model) == impurity_importance(model.ensemble, model.coeffs)
+    @test split_importance(model) == split_importance(model.ensemble, model.coeffs)
+    @test isapprox(
+        permutation_importance(model, features, labels; rng=StableRNG(1)).mean,
+        permutation_importance(
+            (model.ensemble, model.coeffs),
+            labels,
+            features,
+            (model, y, X) -> accuracy(y, apply_adaboost_stumps(model, X));
+            rng=StableRNG(1),
+        ).mean,
+    )
 
-model = fit!(AdaBoostStumpClassifier(; rng=StableRNG(1)), features, labels)
-# Adaboost isn't so hot on this task, disabled for now
-mean(predict(model, features) .== labels)
-@test impurity_importance(model) == impurity_importance(model.ensemble, model.coeffs)
-@test split_importance(model) == split_importance(model.ensemble, model.coeffs)
-@test isapprox(permutation_importance(model, features, labels, rng=StableRNG(1)).mean, permutation_importance((model.ensemble, model.coeffs), labels, features, (model, y, X) -> accuracy(y, apply_adaboost_stumps(model, X)), rng=StableRNG(1)).mean)
+    N = 3000
+    X = randn(StableRNG(1), N, 10)
+    # TODO: we should probably support fit!(::DecisionTreeClassifier, ::BitArray)
+    y = convert(Vector{Bool}, randn(N) .< 0)
+    max_depth = 5
+    model = fit!(DecisionTreeClassifier(; rng=StableRNG(1), max_depth), X, y)
+    @test depth(model) == max_depth
 
+    ## Test that the RNG arguments work as expected
+    Random.seed!(2)
+    X = randn(StableRNG(1), 100, 10)
+    y = rand(StableRNG(1), Bool, 100)
 
-N = 3000
-X = randn(StableRNG(1), N, 10)
-# TODO: we should probably support fit!(::DecisionTreeClassifier, ::BitArray)
-y = convert(Vector{Bool}, randn(N) .< 0)
-max_depth = 5
-model = fit!(DecisionTreeClassifier(; rng=StableRNG(1), max_depth=max_depth), X, y)
-@test depth(model) == max_depth
-
-## Test that the RNG arguments work as expected
-Random.seed!(2)
-X = randn(StableRNG(1), 100, 10)
-y = rand(StableRNG(1), Bool, 100);
-
-@test predict_proba(fit!(RandomForestClassifier(; rng=10), X, y), X) ==
-    predict_proba(fit!(RandomForestClassifier(; rng=10), X, y), X)
-@test predict_proba(fit!(RandomForestClassifier(; rng=10), X, y), X) !=
-    predict_proba(fit!(RandomForestClassifier(; rng=12), X, y), X)
-
+    @test predict_proba(fit!(RandomForestClassifier(; rng=10), X, y), X) ==
+        predict_proba(fit!(RandomForestClassifier(; rng=10), X, y), X)
+    @test predict_proba(fit!(RandomForestClassifier(; rng=10), X, y), X) !=
+        predict_proba(fit!(RandomForestClassifier(; rng=12), X, y), X)
 end # @testset

--- a/test/miscellaneous/abstract_trees_test.jl
+++ b/test/miscellaneous/abstract_trees_test.jl
@@ -2,102 +2,116 @@
 
 @testset "abstract_trees_test.jl" begin
 
-# CAVEAT:   These tests rely heavily on the texts generated in `printnode`.
-#           After changes in `printnode` the following `*pattern`s might be adapted.
+    # CAVEAT:   These tests rely heavily on the texts generated in `printnode`.
+    #           After changes in `printnode` the following `*pattern`s might be adapted.
 
-### Some content-checking helpers
-# if no feature names or class labels are given, the following keywords must be present
-featid_pattern          = "Feature: "               # feature ids are prepended by this text
-classid_pattern         = "Class: "                 # `Leaf.majority` is prepended by this text
-# if feature names and class labels are given, they can be identified within the tree using these patterns
-fname_pattern(fname)    = fname * " <"            # feature names are followed by " <"
-clabel_pattern(clabel)  = "─ " * clabel * " ("      # class labels are embedded in "─ " and " ("
+    ### Some content-checking helpers
+    # if no feature names or class labels are given, the following keywords must be present
+    featid_pattern = "Feature: "               # feature ids are prepended by this text
+    classid_pattern = "Class: "                 # `Leaf.majority` is prepended by this text
+    # if feature names and class labels are given, they can be identified within the tree using these patterns
+    fname_pattern(fname) = fname * " <"            # feature names are followed by " <"
+    clabel_pattern(clabel) = "─ " * clabel * " ("      # class labels are embedded in "─ " and " ("
 
-# occur all elements of `pool` in the form defined by `fname_/clabel_pattern` in `str_tree`?  
-check_occurence(str_tree, pool, pattern) = count(map(elem -> occursin(pattern(elem), str_tree), pool)) == length(pool)
+    # occur all elements of `pool` in the form defined by `fname_/clabel_pattern` in `str_tree`?  
+    function check_occurence(str_tree, pool, pattern)
+        count(map(elem -> occursin(pattern(elem), str_tree), pool)) == length(pool)
+    end
 
-@info("Test base functionality")    
-l1 = Leaf(1, [1,1,2])
-l2 = Leaf(2, [1,2,2])
-l3 = Leaf(3, [3,3,1])
-n2 = Node(2, 0.5, l2, l3)
-n1 = Node(1, 0.7, l1, n2)
-feature_names = ["firstFt", "secondFt"]
-class_labels = ["a", "b", "c"]
+    @info("Test base functionality")
+    l1 = Leaf(1, [1, 1, 2])
+    l2 = Leaf(2, [1, 2, 2])
+    l3 = Leaf(3, [3, 3, 1])
+    n2 = Node(2, 0.5, l2, l3)
+    n1 = Node(1, 0.7, l1, n2)
+    feature_names = ["firstFt", "secondFt"]
+    class_labels = ["a", "b", "c"]
 
-infotree1 = wrap(n1, (featurenames = feature_names, classlabels = class_labels))
-infotree2 = wrap(n1, (featurenames = feature_names,))
-infotree3 = wrap(n1, (classlabels = class_labels,))
-infotree4 = wrap(n1, (x = feature_names, y = class_labels))
-infotree5 = wrap(n1)
+    infotree1 = wrap(n1, (featurenames=feature_names, classlabels=class_labels))
+    infotree2 = wrap(n1, (featurenames=feature_names,))
+    infotree3 = wrap(n1, (classlabels=class_labels,))
+    infotree4 = wrap(n1, (x=feature_names, y=class_labels))
+    infotree5 = wrap(n1)
 
-@info(" -- Tree with feature names and class labels")
-AbstractTrees.print_tree(infotree1)
-rep1 = AbstractTrees.repr_tree(infotree1)
-@test check_occurence(rep1, feature_names, fname_pattern)
-@test check_occurence(rep1, class_labels, clabel_pattern)
+    @info(" -- Tree with feature names and class labels")
+    AbstractTrees.print_tree(infotree1)
+    rep1 = AbstractTrees.repr_tree(infotree1)
+    @test check_occurence(rep1, feature_names, fname_pattern)
+    @test check_occurence(rep1, class_labels, clabel_pattern)
 
-@info(" -- Tree with feature names")
-AbstractTrees.print_tree(infotree2)
-rep2 = AbstractTrees.repr_tree(infotree2)
-@test check_occurence(rep2, feature_names, fname_pattern)
-@test occursin(classid_pattern, rep2)
+    @info(" -- Tree with feature names")
+    AbstractTrees.print_tree(infotree2)
+    rep2 = AbstractTrees.repr_tree(infotree2)
+    @test check_occurence(rep2, feature_names, fname_pattern)
+    @test occursin(classid_pattern, rep2)
 
-@info(" -- Tree with class labels")
-AbstractTrees.print_tree(infotree3)
-rep3 = AbstractTrees.repr_tree(infotree3)
-@test occursin(featid_pattern, rep3)
-@test check_occurence(rep3, class_labels, clabel_pattern)
+    @info(" -- Tree with class labels")
+    AbstractTrees.print_tree(infotree3)
+    rep3 = AbstractTrees.repr_tree(infotree3)
+    @test occursin(featid_pattern, rep3)
+    @test check_occurence(rep3, class_labels, clabel_pattern)
 
-@info(" -- Tree with ids only (nonsense parameters)")
-AbstractTrees.print_tree(infotree4)
-rep4 = AbstractTrees.repr_tree(infotree4)
-@test occursin(featid_pattern, rep4)
-@test occursin(classid_pattern, rep4)
+    @info(" -- Tree with ids only (nonsense parameters)")
+    AbstractTrees.print_tree(infotree4)
+    rep4 = AbstractTrees.repr_tree(infotree4)
+    @test occursin(featid_pattern, rep4)
+    @test occursin(classid_pattern, rep4)
 
-@info(" -- Tree with ids only")
-AbstractTrees.print_tree(infotree5)
-rep5 = AbstractTrees.repr_tree(infotree5)
-@test occursin(featid_pattern, rep5)
-@test occursin(classid_pattern, rep5)
-    
-@info("Test `children` with 'adult' decision tree")
-@info(" -- Preparing test data")
-features, labels = load_data("adult")
-feature_names_adult = ["age", "workclass", "fnlwgt", "education", "education-num", "marital-status", "occupation",
-        "relationship", "race", "sex", "capital-gain", "capital-loss", "hours-per-week", "native-country"]
-model = build_tree(labels, features)
-wrapped_tree = wrap(model, (featurenames = feature_names_adult,))
+    @info(" -- Tree with ids only")
+    AbstractTrees.print_tree(infotree5)
+    rep5 = AbstractTrees.repr_tree(infotree5)
+    @test occursin(featid_pattern, rep5)
+    @test occursin(classid_pattern, rep5)
 
-@info(" -- Test `children`")
-function traverse_tree(node::InfoNode)
-    l, r = AbstractTrees.children(node)
-    @test l.info == node.info
-    @test r.info == node.info
-    traverse_tree(l)
-    traverse_tree(r)
-end
+    @info("Test `children` with 'adult' decision tree")
+    @info(" -- Preparing test data")
+    features, labels = load_data("adult")
+    feature_names_adult = [
+        "age",
+        "workclass",
+        "fnlwgt",
+        "education",
+        "education-num",
+        "marital-status",
+        "occupation",
+        "relationship",
+        "race",
+        "sex",
+        "capital-gain",
+        "capital-loss",
+        "hours-per-week",
+        "native-country",
+    ]
+    model = build_tree(labels, features)
+    wrapped_tree = wrap(model, (featurenames=feature_names_adult,))
 
-traverse_tree(leaf::InfoLeaf) = nothing
+    @info(" -- Test `children`")
+    function traverse_tree(node::InfoNode)
+        l, r = AbstractTrees.children(node)
+        @test l.info == node.info
+        @test r.info == node.info
+        traverse_tree(l)
+        traverse_tree(r)
+    end
 
-traverse_tree(wrapped_tree)
+    traverse_tree(leaf::InfoLeaf) = nothing
+
+    traverse_tree(wrapped_tree)
 end
 
 @testset "abstract_trees - test misuse" begin
+    @info("Test misuse of `classlabel` information")
 
-    @info("Test misuse of `classlabel` information") 
-
-    @info("Create test data - a decision tree based on the iris data set") 
-    features, labels = load_data("iris") 
+    @info("Create test data - a decision tree based on the iris data set")
+    features, labels = load_data("iris")
     features = float.(features)
-    labels   = string.(labels)
+    labels = string.(labels)
     model = DecisionTreeClassifier()
-    fit!(model, features, labels)    
+    fit!(model, features, labels)
 
     @info("Try to replace the exisitng class labels")
     class_labels = unique(labels)
     dtree = model.root.node
-    wt = DecisionTree.wrap(dtree, (classlabels = class_labels,))
+    wt = DecisionTree.wrap(dtree, (classlabels=class_labels,))
     @test_throws AssertionError AbstractTrees.print_tree(wt)
-
 end

--- a/test/miscellaneous/convert.jl
+++ b/test/miscellaneous/convert.jl
@@ -1,44 +1,42 @@
 # Test conversion of Leaf to Node
 
 @testset "convert.jl" begin
+    lf = Leaf(1, [1])
+    nv = Node{Int,Int}[]
+    rv = Root{Int,Int}[]
+    push!(nv, lf)
+    push!(rv, lf)
+    push!(rv, nv[1])
+    @test apply_tree(nv[1], [0]) == 1
+    @test apply_tree(rv[1], [0]) == 1
+    @test apply_tree(rv[2], [0]) == 1
 
-lf = Leaf(1, [1])
-nv = Node{Int, Int}[]
-rv = Root{Int, Int}[]
-push!(nv, lf)
-push!(rv, lf)
-push!(rv, nv[1])
-@test apply_tree(nv[1], [0]) == 1
-@test apply_tree(rv[1], [0]) == 1
-@test apply_tree(rv[2], [0]) == 1
+    lf = Leaf(1.0, [0.0, 1.0])
+    nv = Node{Int,Float64}[]
+    rv = Root{Int,Float64}[]
+    push!(nv, lf)
+    push!(rv, lf)
+    push!(rv, nv[1])
+    @test apply_tree(nv[1], [0]) == 1.0
+    @test apply_tree(rv[1], [0]) == 1.0
+    @test apply_tree(rv[2], [0]) == 1.0
 
-lf = Leaf(1.0, [0.0, 1.0])
-nv = Node{Int, Float64}[]
-rv = Root{Int, Float64}[]
-push!(nv, lf)
-push!(rv, lf)
-push!(rv, nv[1])
-@test apply_tree(nv[1], [0]) == 1.0
-@test apply_tree(rv[1], [0]) == 1.0
-@test apply_tree(rv[2], [0]) == 1.0
-
-lf = Leaf("A", ["B", "A"])
-nv = Node{Int, String}[]
-rv = Root{Int, String}[]
-push!(nv, lf)
-push!(rv, lf)
-push!(rv, nv[1])
-@test apply_tree(nv[1], [0]) == "A"
-@test apply_tree(rv[1], [0]) == "A"
-@test apply_tree(rv[2], [0]) == "A"
-
+    lf = Leaf("A", ["B", "A"])
+    nv = Node{Int,String}[]
+    rv = Root{Int,String}[]
+    push!(nv, lf)
+    push!(rv, lf)
+    push!(rv, nv[1])
+    @test apply_tree(nv[1], [0]) == "A"
+    @test apply_tree(rv[1], [0]) == "A"
+    @test apply_tree(rv[2], [0]) == "A"
 end
 
 @testset "convert to text" begin
-    n, m = 10^3, 5;
-    features = rand(StableRNG(1), n, m);
-    weights = rand(StableRNG(1), -1:1, m);
-    labels = features * weights;
+    n, m = 10^3, 5
+    features = rand(StableRNG(1), n, m)
+    weights = rand(StableRNG(1), -1:1, m)
+    labels = features * weights
     model = fit!(DecisionTreeRegressor(; rng=StableRNG(1)), features, labels)
     # Smoke test.
     print_tree(devnull, model)

--- a/test/miscellaneous/ensemble_methods.jl
+++ b/test/miscellaneous/ensemble_methods.jl
@@ -16,7 +16,7 @@
     n1 = length(ensemble1.trees)
     n2 = length(ensemble2.trees)
     n = n1 + n2
-    @test n*ensemble.featim ≈ n1*ensemble1.featim + n2*ensemble2.featim
+    @test n * ensemble.featim ≈ n1 * ensemble1.featim + n2 * ensemble2.featim
 
     # including an ensemble without impurity importance should drop impurity importance from
     # the combination:
@@ -31,4 +31,3 @@
     @test_logs vcat(ensemble3, ensemble4) # ensemble 3 doesn't support importances
     @test_throws DecisionTree.ERR_ENSEMBLE_VCAT vcat(ensemble1, ensemble4)
 end
-

--- a/test/miscellaneous/feature_importance_test.jl
+++ b/test/miscellaneous/feature_importance_test.jl
@@ -1,187 +1,244 @@
 @testset "feature_importance_test.jl" begin
+    X = [
+        -3 2 2
+        -2 -2 -3
+        -2 0 2
+        -1 -3 1
+        -1 -1 0
+        2 -3 1
+        1 -2 0
+        3 -2 3
+        1 -1 2
+        2 -1 -2
+        2 0 1
+        5 0 0
+        1 0 2
+        3 1 -1
+        1 4 -3
+        5 5 -2
+        6 3 -1
+        4 2 0
+        4 3 2
+        5 2 4
+    ]
+    y = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1]
 
-X = [
-    -3   2   2;
-    -2  -2  -3;
-    -2   0   2;
-    -1  -3   1;
-    -1  -1   0;
-     2  -3   1;
-     1  -2   0;
-     3  -2   3;
-     1  -1   2;
-     2  -1  -2;
-     2   0   1;
-     5   0   0;
-     1   0   2;
-     3   1  -1;
-     1   4  -3;
-     5   5  -2;
-     6   3  -1;
-     4   2   0;
-     4   3   2;
-     5   2   4 ]
-y = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1]
+    # classifier
+    model = build_tree(y, X)
+    entropy1 = -(10 * log(10 / 20) + 10 * log(10 / 20)) / 20
+    entropy2 = -(5 * log(5 / 15) + 10 * log(10 / 15)) / 20
+    entropy3 = -(5 * log(5 / 7) + 2 * log(2 / 7)) / 20
+    @test isapprox(
+        impurity_importance(model), [entropy1 - entropy2, entropy2 - entropy3, entropy3]
+    )
+    @test split_importance(model) == [1, 1, 1]
 
-# classifier
-model = build_tree(y, X)
-entropy1 = -(10 * log(10 / 20) + 10 * log(10 / 20)) / 20
-entropy2 = -(5 * log(5 / 15) + 10 * log(10 / 15)) / 20
-entropy3 = -(5 * log(5 / 7) + 2 * log(2 / 7)) / 20
-@test isapprox(impurity_importance(model), [entropy1 - entropy2, entropy2 - entropy3, entropy3])
-@test split_importance(model) == [1, 1, 1]
+    # prune_tree
+    pt = prune_tree(model, 0.7)
+    @test isapprox(impurity_importance(pt), [entropy1 - entropy2, entropy2 - entropy3, 0])
+    @test split_importance(pt) == [1, 1, 0]
 
-# prune_tree
-pt = prune_tree(model, 0.7)
-@test isapprox(impurity_importance(pt), [entropy1 - entropy2, entropy2 - entropy3, 0])
-@test split_importance(pt) == [1, 1, 0]
+    pt = prune_tree(model, 0.6)
+    @test isapprox(impurity_importance(pt), [entropy1 - entropy2, 0, 0])
+    @test split_importance(pt) == [1, 0, 0]
 
-pt = prune_tree(model, 0.6)
-@test isapprox(impurity_importance(pt), [entropy1 - entropy2, 0, 0])
-@test split_importance(pt) == [1, 0, 0]
+    # regressor
+    model = build_tree(float.(y), X, 0, -1, 2)
+    mse1 = ((1^2 * 10 + 0^2 * 10) / 20 - ((1 * 10 + 0 * 10) / 20)^2)
+    mse2 = ((1^2 * 10 + 0^2 * 5) / 15 - ((1 * 10 + 0 * 5) / 15)^2) * 15 / 20
+    mse3 = ((1^2 * 2 + 0^2 * 5) / 7 - ((1 * 2 + 0 * 5) / 7)^2) * 7 / 20
+    @test isapprox(impurity_importance(model), [mse1 - mse2, mse2 - mse3, mse3])
+    @test split_importance(model) == [1, 1, 1]
 
-# regressor
-model = build_tree(float.(y), X, 0, -1, 2)
-mse1 = ((1^2 * 10 + 0^2 * 10) / 20 - ((1 * 10 + 0 * 10) / 20)^2)
-mse2 = ((1^2 * 10 + 0^2 * 5) / 15 - ((1 * 10 + 0 * 5) / 15)^2) * 15 / 20
-mse3 = ((1^2 * 2 + 0^2 * 5) / 7 - ((1 * 2 + 0 * 5) / 7)^2) * 7 / 20
-@test isapprox(impurity_importance(model), [mse1 - mse2, mse2 - mse3, mse3])
-@test split_importance(model) == [1, 1, 1]
+    # prune_tree
+    pt = prune_tree(model, 0.7)
+    @test isapprox(impurity_importance(pt), [mse1 - mse2, mse2 - mse3, 0])
+    @test split_importance(pt) == [1, 1, 0]
 
-# prune_tree
-pt = prune_tree(model, 0.7)
-@test isapprox(impurity_importance(pt), [mse1 - mse2, mse2 - mse3, 0])
-@test split_importance(pt) == [1, 1, 0]
+    pt = prune_tree(model, 0.6)
+    @test isapprox(impurity_importance(pt), [mse1 - mse2, 0, 0])
+    @test split_importance(pt) == [1, 0, 0]
 
-pt = prune_tree(model, 0.6)
-@test isapprox(impurity_importance(pt), [mse1 - mse2, 0, 0])
-@test split_importance(pt) == [1, 0, 0]
+    # Increase samples for testing permutation_importance and ensemble models
+    X2 = repeat(X; inner=(50, 1)) .+ rand(StableRNG(1), 1000, 3)
+    y2 = repeat(y; inner=50)
 
-# Increase samples for testing permutation_importance and ensemble models
-X2 = repeat(X, inner = (50, 1)) .+ rand(StableRNG(1), 1000, 3)
-y2 = repeat(y, inner = 50)
+    # classifier
+    model = build_tree(y2, X2; rng=StableRNG(1))
+    p1 = permutation_importance(
+        model,
+        y2,
+        X2,
+        (model, y, X) -> accuracy(y, apply_tree(model, X)),
+        10;
+        rng=StableRNG(1),
+    )
+    @test similarity(
+        impurity_importance(model), [entropy1 - entropy2, entropy2 - entropy3, entropy3]
+    ) > 0.9
+    @test similarity(split_importance(model), [1, 1, 1]) > 0.9
+    @test argmax(p1.mean) == 1
+    @test argmin(p1.mean) == 3
 
-# classifier
-model = build_tree(y2, X2, rng=StableRNG(1))
-p1 = permutation_importance(model, y2, X2, (model, y, X) -> accuracy(y, apply_tree(model, X)), 10; rng=StableRNG(1))
-@test similarity(impurity_importance(model), [entropy1 - entropy2, entropy2 - entropy3, entropy3]) > 0.9
-@test similarity(split_importance(model), [1, 1, 1]) > 0.9
-@test argmax(p1.mean) == 1
-@test argmin(p1.mean) == 3
+    model = build_forest(y2, X2, -1, 100; rng=StableRNG(1))
+    i1 = impurity_importance(model)
+    s1 = split_importance(model)
+    p1 = permutation_importance(
+        model,
+        y2,
+        X2,
+        (model, y, X) -> accuracy(y, apply_forest(model, X)),
+        10;
+        rng=StableRNG(1),
+    )
+    model = build_forest(y2, X2, -1, 100; rng=StableRNG(100))
+    i2 = impurity_importance(model)
+    s2 = split_importance(model)
+    p2 = permutation_importance(
+        model,
+        y2,
+        X2,
+        (model, y, X) -> accuracy(y, apply_forest(model, X)),
+        10;
+        rng=StableRNG(100),
+    )
+    @test argmin(p1.mean) == argmin(p2.mean)
+    @test (-(sort(p1.mean; rev=true)[1:2]...) - -(sort(p2.mean; rev=true)[1:2]...)) < 0.2
+    @test similarity(i1, i2) > 0.9
+    @test similarity(s1, s2) > 0.9
 
-model = build_forest(y2, X2, -1, 100, rng=StableRNG(1))
-i1 = impurity_importance(model)
-s1 = split_importance(model)
-p1 = permutation_importance(model, y2, X2, (model, y, X) -> accuracy(y, apply_forest(model, X)), 10; rng=StableRNG(1)) 
-model = build_forest(y2, X2, -1, 100, rng=StableRNG(100))
-i2 = impurity_importance(model)
-s2 = split_importance(model)
-p2 = permutation_importance(model, y2, X2, (model, y, X) -> accuracy(y, apply_forest(model, X)), 10; rng=StableRNG(100)) 
-@test argmin(p1.mean) == argmin(p2.mean)
-@test (-(sort(p1.mean, rev = true)[1:2]...) - -(sort(p2.mean, rev = true)[1:2]...)) < 0.2
-@test similarity(i1, i2) > 0.9
-@test similarity(s1, s2) > 0.9
+    model, coeffs = build_adaboost_stumps(y2, X2, 20; rng=StableRNG(1))
+    s1 = split_importance(model)
+    p1 = permutation_importance(
+        (model, coeffs),
+        y2,
+        X2,
+        (model, y, X) -> accuracy(y, apply_adaboost_stumps(model, X)),
+        10;
+        rng=StableRNG(1),
+    )
+    model, coeffs = build_adaboost_stumps(y2, X2, 20; rng=StableRNG(100))
+    s2 = split_importance(model)
+    p2 = permutation_importance(
+        (model, coeffs),
+        y2,
+        X2,
+        (model, y, X) -> accuracy(y, apply_adaboost_stumps(model, X)),
+        10;
+        rng=StableRNG(100),
+    )
+    @test argmin(p1.mean) == argmin(p2.mean)
+    @test (-(sort(p1.mean; rev=true)[1:2]...) - -(sort(p2.mean; rev=true)[1:2]...)) < 0.1
+    @test similarity(s1, s2) > 0.9
 
-model, coeffs = build_adaboost_stumps(y2, X2, 20; rng=StableRNG(1))
-s1 = split_importance(model)
-p1 = permutation_importance((model, coeffs), y2, X2, (model, y, X) -> accuracy(y, apply_adaboost_stumps(model, X)), 10; rng=StableRNG(1)) 
-model, coeffs = build_adaboost_stumps(y2, X2, 20; rng=StableRNG(100))
-s2 = split_importance(model)
-p2 = permutation_importance((model, coeffs), y2, X2, (model, y, X) -> accuracy(y, apply_adaboost_stumps(model, X)), 10; rng=StableRNG(100)) 
-@test argmin(p1.mean) == argmin(p2.mean)
-@test (-(sort(p1.mean, rev = true)[1:2]...) - -(sort(p2.mean, rev = true)[1:2]...)) < 0.1
-@test similarity(s1, s2) > 0.9
+    # regressor
+    y2 = y2 .+ rand(StableRNG(1), 1000) ./ 100
+    model = build_tree(y2, X2, 0, 3, 5, 2, 0.01; rng=StableRNG(1))
+    p1 = permutation_importance(
+        model, y2, X2, (model, y, X) -> R2(y, apply_tree(model, X)), 10; rng=StableRNG(1)
+    )
+    @test similarity(impurity_importance(model), [mse1 - mse2, mse2 - mse3, mse3]) > 0.9
+    @test similarity(split_importance(model), [1, 1, 1]) > 0.9
+    @test argmax(p1.mean) == 1
+    @test argmin(p1.mean) == 3
 
-# regressor
-y2 = y2 .+ rand(StableRNG(1), 1000) ./ 100
-model = build_tree(y2, X2, 0, 3, 5, 2, 0.01, rng=StableRNG(1))
-p1 = permutation_importance(model, y2, X2, (model, y, X) -> R2(y, apply_tree(model, X)), 10; rng=StableRNG(1))
-@test similarity(impurity_importance(model), [mse1 - mse2, mse2 - mse3, mse3]) > 0.9
-@test similarity(split_importance(model), [1, 1, 1]) > 0.9
-@test argmax(p1.mean) == 1
-@test argmin(p1.mean) == 3
+    model = build_forest(y2, X2, 0, 100, 0.7, 3, 5, 2, 0.01; rng=StableRNG(1))
+    i1 = impurity_importance(model)
+    s1 = split_importance(model)
+    p1 = permutation_importance(
+        model, y2, X2, (model, y, X) -> R2(y, apply_forest(model, X)), 10; rng=StableRNG(1)
+    )
+    model = build_forest(y2, X2, 0, 100, 0.7, 3, 5, 2, 0.01; rng=StableRNG(100))
+    i2 = impurity_importance(model)
+    s2 = split_importance(model)
+    p2 = permutation_importance(
+        model,
+        y2,
+        X2,
+        (model, y, X) -> R2(y, apply_forest(model, X)),
+        10;
+        rng=StableRNG(100),
+    )
+    @test argmax(p1.mean) == argmax(p2.mean)
+    @test argmin(p1.mean) == argmin(p2.mean)
+    @test similarity(i1, i2) > 0.9
+    @test similarity(s1, s2) > 0.9
 
-model = build_forest(y2, X2, 0, 100, 0.7, 3, 5, 2, 0.01, rng=StableRNG(1))
-i1 = impurity_importance(model)
-s1 = split_importance(model)
-p1 = permutation_importance(model, y2, X2, (model, y, X) -> R2(y, apply_forest(model, X)), 10; rng=StableRNG(1)) 
-model = build_forest(y2, X2, 0, 100, 0.7, 3, 5, 2, 0.01, rng=StableRNG(100))
-i2 = impurity_importance(model)
-s2 = split_importance(model)
-p2 = permutation_importance(model, y2, X2, (model, y, X) -> R2(y, apply_forest(model, X)), 10; rng=StableRNG(100)) 
-@test argmax(p1.mean) == argmax(p2.mean)
-@test argmin(p1.mean) == argmin(p2.mean)
-@test similarity(i1, i2) > 0.9
-@test similarity(s1, s2) > 0.9
+    # Common datasets
+    X, y = load_data("digits")
 
-# Common datasets
-X, y = load_data("digits")
+    # classifier
+    model = build_tree(y, X, 0, 3, 1, 2; rng=StableRNG(1))
+    # sklearn equivalent: 
+    # model = DecisionTreeClassifier(max_depth = 3, criterion = 'entropy', random_state = 1)
+    # model.fit(X, y)
+    @test isapprox(
+        filter(x -> >(x, 0), impurity_importance(model; normalize=true)),
+        [0.11896482, 0.15168659, 0.17920925, 0.29679316, 0.11104555, 0.14230064],
+        atol=0.0000005,
+    )
 
-# classifier
-model = build_tree(y, X, 0, 3, 1, 2; rng=StableRNG(1))
-# sklearn equivalent: 
-# model = DecisionTreeClassifier(max_depth = 3, criterion = 'entropy', random_state = 1)
-# model.fit(X, y)
-@test isapprox(filter(x -> >(x, 0), impurity_importance(model, normalize = true)), [0.11896482, 0.15168659, 0.17920925, 0.29679316, 0.11104555, 0.14230064], atol = 0.0000005)
+    # regressor
+    model = build_tree(float.(y), X, 0, 3, 1, 2; rng=StableRNG(1))
+    # sklearn equivalent: 
+    # model = DecisionTreeRegressor(max_depth = 3, random_state = 1)
+    # model.fit(X, y)
+    @test isapprox(
+        filter(x -> >(x, 0), impurity_importance(model; normalize=true)),
+        [0.1983883, 0.02315617, 0.09821539, 0.06591425, 0.19884457, 0.14939765, 0.26608367],
+        atol=0.0000005,
+    )
 
-# regressor
-model = build_tree(float.(y), X, 0, 3, 1, 2; rng=StableRNG(1))
-# sklearn equivalent: 
-# model = DecisionTreeRegressor(max_depth = 3, random_state = 1)
-# model.fit(X, y)
-@test isapprox(filter(x -> >(x, 0), impurity_importance(model, normalize = true)), [0.1983883, 0.02315617, 0.09821539, 0.06591425, 0.19884457, 0.14939765, 0.26608367], atol = 0.0000005)
+    X, y = load_data("iris")
+    y = String.(y)
 
-X, y = load_data("iris")
-y = String.(y)
+    # classifier
+    model = build_forest(y, X, -1, 100, 0.7, 2; rng=StableRNG(100))
+    # sklearn:
+    # model = RandomForestClassifier(n_estimators = 100, max_depth = 2, random_state = 100, criterion = 'entropy')
+    # model.fit(X, y)
+    f1 = impurity_importance(model)
+    @test sum(f1[1:2]) < 0.25 # About 0.1% will fail among different rng
+    @test abs(f1[4] - f1[3]) < 0.35 # About 1% will fail among different rng
 
-# classifier
-model = build_forest(y, X, -1, 100, 0.7, 2; rng=StableRNG(100))
-# sklearn:
-# model = RandomForestClassifier(n_estimators = 100, max_depth = 2, random_state = 100, criterion = 'entropy')
-# model.fit(X, y)
-f1 = impurity_importance(model)
-@test sum(f1[1:2]) < 0.25 # About 0.1% will fail among different rng
-@test abs(f1[4] - f1[3]) < 0.35 # About 1% will fail among different rng
+    model, coeffs = build_adaboost_stumps(y, X, 10; rng=StableRNG(1))
+    # sklearn:
+    # model = AdaBoostClassifier(base_estimator = DecisionTreeClassifier(max_depth = 1, criterion = 'entropy'),
+    #                           algorithm = 'SAMME', n_estimators = 10, random_state = 1)
+    # model.fit(X, y)
+    f1 = impurity_importance(model, coeffs)
+    @test sum(f1[1:2]) < 0.1            # Very Stable
+    @test 0.35 < (f1[3] - f1[4]) < 0.45 # Very Stable
+    # regressor
+    y2 = repeat([1.0, 2.0, 3.0]; inner=50)
+    model = build_forest(y2, X, 0, 100, 0.7, 2; rng=StableRNG(100))
+    # sklearn:
+    # model = RandomForestRegressor(n_estimators = 100, max_depth = 2, random_state = 100)
+    # model.fit(X, y)
+    f1 = impurity_importance(model)
+    @test sum(f1[1:2]) < 0.1             # Very Stable
 
-model, coeffs = build_adaboost_stumps(y, X, 10; rng=StableRNG(1))
-# sklearn:
-# model = AdaBoostClassifier(base_estimator = DecisionTreeClassifier(max_depth = 1, criterion = 'entropy'),
-#                           algorithm = 'SAMME', n_estimators = 10, random_state = 1)
-# model.fit(X, y)
-f1 = impurity_importance(model, coeffs)
-@test sum(f1[1:2]) < 0.1            # Very Stable
-@test 0.35 < (f1[3] - f1[4]) < 0.45 # Very Stable
-# regressor
-y2 = repeat([1.0, 2.0, 3.0], inner = 50)
-model = build_forest(y2, X, 0, 100, 0.7, 2; rng=StableRNG(100))
-# sklearn:
-# model = RandomForestRegressor(n_estimators = 100, max_depth = 2, random_state = 100)
-# model.fit(X, y)
-f1 = impurity_importance(model)
-@test sum(f1[1:2]) < 0.1             # Very Stable
+    X = X[:, 1:3] # leave only one important feature
+    # classifier
+    model = build_forest(y, X, -1, 100, 0.7, 2; rng=StableRNG(100))
+    # sklearn:
+    # model = RandomForestClassifier(n_estimators = 100, max_depth = 2, random_state = 100, criterion = 'entropy')
+    # model.fit(X, y)
+    f1 = impurity_importance(model)
+    @test argmax(f1) == 3
 
-X = X[:, 1:3] # leave only one important feature
-# classifier
-model = build_forest(y, X, -1, 100, 0.7, 2; rng=StableRNG(100))
-# sklearn:
-# model = RandomForestClassifier(n_estimators = 100, max_depth = 2, random_state = 100, criterion = 'entropy')
-# model.fit(X, y)
-f1 = impurity_importance(model)
-@test argmax(f1) == 3
+    model, coeffs = build_adaboost_stumps(y, X, 10; rng=StableRNG(1))
+    # sklearn:
+    # model = AdaBoostClassifier(base_estimator = DecisionTreeClassifier(max_depth = 1, criterion = 'entropy'),
+    #                           algorithm = 'SAMME', n_estimators = 10, random_state = 1)
+    # model.fit(X, y)
+    @test 0.85 < split_importance(model, coeffs)[3] < 0.95 # Very Stable
 
-model, coeffs = build_adaboost_stumps(y, X, 10; rng=StableRNG(1))
-# sklearn:
-# model = AdaBoostClassifier(base_estimator = DecisionTreeClassifier(max_depth = 1, criterion = 'entropy'),
-#                           algorithm = 'SAMME', n_estimators = 10, random_state = 1)
-# model.fit(X, y)
-@test 0.85 < split_importance(model, coeffs)[3] < 0.95 # Very Stable
-
-# regressor
-model = build_forest(y2, X, 0, 100, 0.7, 2; rng=StableRNG(100))
-# sklearn:
-# model = RandomForestRegressor(n_estimators = 100, max_depth = 2, random_state = 100)
-# model.fit(X, y)
-f1 = impurity_importance(model)
-@test sum(f1[1:2]) < 0.1  # Very Stable
-
+    # regressor
+    model = build_forest(y2, X, 0, 100, 0.7, 2; rng=StableRNG(100))
+    # sklearn:
+    # model = RandomForestRegressor(n_estimators = 100, max_depth = 2, random_state = 100)
+    # model.fit(X, y)
+    f1 = impurity_importance(model)
+    @test sum(f1[1:2]) < 0.1  # Very Stable
 end

--- a/test/miscellaneous/parallel.jl
+++ b/test/miscellaneous/parallel.jl
@@ -1,34 +1,31 @@
 # Test parallelization of random forests
 
 @testset "parallel.jl" begin
+    Distributed.addprocs(1)
+    @test Distributed.nprocs() > 1
 
-Distributed.addprocs(1)
-@test Distributed.nprocs() > 1
+    Distributed.@everywhere using DecisionTree
 
-Distributed.@everywhere using DecisionTree
+    Random.seed!(16)
 
-Random.seed!(16)
+    # Classification
+    n, m = 10^3, 5
+    features = rand(n, m)
+    weights = rand(-1:1, m)
+    labels = round.(Int, features * weights)
 
-# Classification
-n,m = 10^3, 5;
-features = rand(n,m);
-weights = rand(-1:1,m);
-labels = round.(Int, features * weights);
+    model = build_forest(labels, features, 2, 10)
+    preds = apply_forest(model, features)
+    cm = confusion_matrix(labels, preds)
+    @test cm.accuracy > 0.8
 
-model = build_forest(labels, features, 2, 10);
-preds = apply_forest(model, features);
-cm = confusion_matrix(labels, preds);
-@test cm.accuracy > 0.8
+    # Regression
+    n, m = 10^3, 5
+    features = randn(n, m)
+    weights = rand(-2:2, m)
+    labels = features * weights
 
-
-# Regression
-n,m = 10^3, 5 ;
-features = randn(n,m);
-weights = rand(-2:2,m);
-labels = features * weights;
-
-model = build_forest(labels, features, 2, 10);
-preds = apply_forest(model, features);
-@test R2(labels, preds) > 0.8
-
+    model = build_forest(labels, features, 2, 10)
+    preds = apply_forest(model, features)
+    @test R2(labels, preds) > 0.8
 end # @testset

--- a/test/regression/digits.jl
+++ b/test/regression/digits.jl
@@ -1,74 +1,60 @@
 @testset "digits.jl" begin
+    X, Y = load_data("digits")
 
-X, Y = load_data("digits")
+    Y = float.(Y) # labels/targets to Float to enable regression
 
-Y = float.(Y) # labels/targets to Float to enable regression
+    min_samples_leaf = 1
+    n_subfeatures = 0
+    max_depth = -1
+    t = DecisionTree.build_tree(Y, X, n_subfeatures, max_depth, min_samples_leaf)
+    @test length(t) in [190, 191]
 
-min_samples_leaf    = 1
-n_subfeatures       = 0
-max_depth           = -1
-t = DecisionTree.build_tree(
-        Y, X,
-        n_subfeatures,
-        max_depth,
-        min_samples_leaf)
-@test length(t) in [190, 191]
+    min_samples_leaf = 5
+    t = DecisionTree.build_tree(Y, X, n_subfeatures, max_depth, min_samples_leaf)
+    @test length(t) == 126
 
-min_samples_leaf    = 5
-t = DecisionTree.build_tree(
-        Y, X,
-        n_subfeatures,
-        max_depth,
-        min_samples_leaf)
-@test length(t) == 126
+    min_samples_leaf = 5
+    n_subfeatures = 0
+    max_depth = 6
+    t = DecisionTree.build_tree(Y, X, n_subfeatures, max_depth, min_samples_leaf)
+    @test length(t) == 44
+    @test depth(t) == 6
 
-min_samples_leaf    = 5
-n_subfeatures       = 0
-max_depth           = 6
-t = DecisionTree.build_tree(
-        Y, X,
-        n_subfeatures,
-        max_depth,
-        min_samples_leaf)
-@test length(t) == 44
-@test depth(t) == 6
+    min_samples_leaf = 1
+    n_subfeatures = 0
+    max_depth = -1
+    min_samples_split = 20
+    t = DecisionTree.build_tree(
+        Y, X, n_subfeatures, max_depth, min_samples_leaf, min_samples_split
+    )
+    @test length(t) == 122
 
-min_samples_leaf    = 1
-n_subfeatures       = 0
-max_depth           = -1
-min_samples_split   = 20
-t = DecisionTree.build_tree(
-        Y, X,
-        n_subfeatures,
-        max_depth,
-        min_samples_leaf,
-        min_samples_split)
-@test length(t) == 122
-
-min_samples_leaf    = 1
-n_subfeatures       = 0
-max_depth           = -1
-min_samples_split   = 2
-min_purity_increase = 0.25
-t = DecisionTree.build_tree(
-        Y, X,
+    min_samples_leaf = 1
+    n_subfeatures = 0
+    max_depth = -1
+    min_samples_split = 2
+    min_purity_increase = 0.25
+    t = DecisionTree.build_tree(
+        Y,
+        X,
         n_subfeatures,
         max_depth,
         min_samples_leaf,
         min_samples_split,
-        min_purity_increase)
-@test length(t) == 103
+        min_purity_increase,
+    )
+    @test length(t) == 103
 
-
-n_subfeatures       = 3
-n_trees             = 10
-partial_sampling    = 0.7
-max_depth           = -1
-min_samples_leaf    = 5
-min_samples_split   = 2
-min_purity_increase = 0.0
-model = build_forest(
-        Y, X,
+    n_subfeatures = 3
+    n_trees = 10
+    partial_sampling = 0.7
+    max_depth = -1
+    min_samples_leaf = 5
+    min_samples_split = 2
+    min_purity_increase = 0.0
+    model = build_forest(
+        Y,
+        X,
         n_subfeatures,
         n_trees,
         partial_sampling,
@@ -76,25 +62,34 @@ model = build_forest(
         min_samples_leaf,
         min_samples_split,
         min_purity_increase;
-        rng=StableRNG(1))
-preds = apply_forest(model, X)
-@test R2(Y, preds) > 0.8
+        rng=StableRNG(1),
+    )
+    preds = apply_forest(model, X)
+    @test R2(Y, preds) > 0.8
 
-preds_MT = apply_forest(model, X, use_multithreading = true)
-@test R2(Y, preds_MT) > 0.8
-@test sum(abs.(preds .- preds_MT)) < 1e-8
+    preds_MT = apply_forest(model, X; use_multithreading=true)
+    @test R2(Y, preds_MT) > 0.8
+    @test sum(abs.(preds .- preds_MT)) < 1e-8
 
-println("\n##### 3 foldCV Regression Tree #####")
-n_folds = 5
-r2 = nfoldCV_tree(Y, X, n_folds; rng=StableRNG(1), verbose=false);
-@test mean(r2) > 0.55
+    println("\n##### 3 foldCV Regression Tree #####")
+    n_folds = 5
+    r2 = nfoldCV_tree(Y, X, n_folds; rng=StableRNG(1), verbose=false)
+    @test mean(r2) > 0.55
 
-println("\n##### 3 foldCV Regression Forest #####")
-n_subfeatures = 2
-n_trees = 10
-n_folds = 5
-partial_sampling = 0.5
-r2 = nfoldCV_forest(Y, X, n_folds, n_subfeatures, n_trees, partial_sampling; rng=StableRNG(1), verbose=false)
-@test mean(r2) > 0.55
-
+    println("\n##### 3 foldCV Regression Forest #####")
+    n_subfeatures = 2
+    n_trees = 10
+    n_folds = 5
+    partial_sampling = 0.5
+    r2 = nfoldCV_forest(
+        Y,
+        X,
+        n_folds,
+        n_subfeatures,
+        n_trees,
+        partial_sampling;
+        rng=StableRNG(1),
+        verbose=false,
+    )
+    @test mean(r2) > 0.55
 end # @testset

--- a/test/regression/energy.jl
+++ b/test/regression/energy.jl
@@ -2,31 +2,28 @@
 # https://archive.ics.uci.edu/ml/datasets/Appliances+energy+prediction
 
 @testset "energy.jl" begin
+    download(
+        "https://archive.ics.uci.edu/ml/machine-learning-databases/00374/energydata_complete.csv",
+        "energy.csv",
+    )
+    energy = readcsv("energy.csv")
 
-download("https://archive.ics.uci.edu/ml/machine-learning-databases/00374/energydata_complete.csv", "energy.csv");
-energy = readcsv("energy.csv");
+    features = energy[2:end, 3:end]
+    labels = float.(energy[2:end, 2])
 
-features = energy[2:end, 3:end];
-labels = float.(energy[2:end, 2]);
+    # over-fitting
+    n_subfeatures = 0
+    max_depth = -1
+    min_samples_leaf = 1
+    model = build_tree(labels, features, n_subfeatures, max_depth, min_samples_leaf)
+    preds = apply_tree(model, features)
+    @test R2(labels, preds) > 0.99
 
-# over-fitting
-n_subfeatures       = 0
-max_depth           = -1
-min_samples_leaf    = 1
-model = build_tree(
-        labels, features,
-        n_subfeatures,
-        max_depth,
-        min_samples_leaf)
-preds = apply_tree(model, features);
-@test R2(labels, preds) > 0.99
+    println("\n##### nfoldCV Regression Tree #####")
+    r2 = nfoldCV_tree(labels, features, 3)
+    @test mean(r2) > 0.05
 
-println("\n##### nfoldCV Regression Tree #####")
-r2 = nfoldCV_tree(labels, features, 3);
-@test mean(r2) > 0.05
-
-println("\n##### nfoldCV Regression Forest #####")
-r2 = nfoldCV_forest(labels, features, 2, 10, 3);
-@test mean(r2) > 0.35
-
+    println("\n##### nfoldCV Regression Forest #####")
+    r2 = nfoldCV_forest(labels, features, 2, 10, 3)
+    @test mean(r2) > 0.35
 end # @testset

--- a/test/regression/energy.jl
+++ b/test/regression/energy.jl
@@ -2,11 +2,11 @@
 # https://archive.ics.uci.edu/ml/datasets/Appliances+energy+prediction
 
 @testset "energy.jl" begin
-    download(
-        "https://archive.ics.uci.edu/ml/machine-learning-databases/00374/energydata_complete.csv",
-        "energy.csv",
-    )
-    energy = readcsv("energy.csv")
+    energy = let
+        url = "https://archive.ics.uci.edu/ml/machine-learning-databases/00374/energydata_complete.csv"
+        tmp_path = download(url)
+        readcsv(tmp_path)
+    end
 
     features = energy[2:end, 3:end]
     labels = float.(energy[2:end, 2])

--- a/test/regression/low_precision.jl
+++ b/test/regression/low_precision.jl
@@ -1,40 +1,42 @@
 @testset "low_precision.jl" begin
+    Random.seed!(5)
 
-Random.seed!(5)
+    n, m = 10^3, 5
+    features = Array{Any}(undef, n, m)
+    features[:, :] = randn(StableRNG(1), n, m)
+    features[:, 1] = round.(Int32, features[:, 1])
+    weights = rand(StableRNG(1), -2:2, m)
+    labels = float.(features * weights)
 
-n, m = 10^3, 5;
-features = Array{Any}(undef, n, m);
-features[:,:] = randn(StableRNG(1), n, m);
-features[:,1] = round.(Int32, features[:,1]);
-weights = rand(StableRNG(1), -2:2, m);
-labels = float.(features * weights);
-
-min_samples_leaf    = Int32(1)
-n_subfeatures       = Int32(0)
-max_depth           = Int32(-1)
-min_samples_split   = Int32(2)
-min_purity_increase = 0.5
-model = build_tree(
-        labels, round.(Int32, features),
+    min_samples_leaf = Int32(1)
+    n_subfeatures = Int32(0)
+    max_depth = Int32(-1)
+    min_samples_split = Int32(2)
+    min_purity_increase = 0.5
+    model = build_tree(
+        labels,
+        round.(Int32, features),
         n_subfeatures,
         max_depth,
         min_samples_leaf,
         min_samples_split,
         min_purity_increase;
-        rng=StableRNG(1))
-preds = apply_tree(model, round.(Int32, features))
-@test R2(labels, preds) < 0.95
-@test typeof(preds) <: Vector{Float64}
+        rng=StableRNG(1),
+    )
+    preds = apply_tree(model, round.(Int32, features))
+    @test R2(labels, preds) < 0.95
+    @test typeof(preds) <: Vector{Float64}
 
-n_subfeatures       = Int32(3)
-n_trees             = Int32(10)
-partial_sampling    = 0.7
-max_depth           = Int32(-1)
-min_samples_leaf    = Int32(5)
-min_samples_split   = Int32(2)
-min_purity_increase = 0.0
-model = build_forest(
-        labels, features,
+    n_subfeatures = Int32(3)
+    n_trees = Int32(10)
+    partial_sampling = 0.7
+    max_depth = Int32(-1)
+    min_samples_leaf = Int32(5)
+    min_samples_split = Int32(2)
+    min_purity_increase = 0.0
+    model = build_forest(
+        labels,
+        features,
         n_subfeatures,
         n_trees,
         partial_sampling,
@@ -42,44 +44,48 @@ model = build_forest(
         min_samples_leaf,
         min_samples_split,
         min_purity_increase;
-        rng=StableRNG(1))
-preds = apply_forest(model, features)
-@test R2(labels, preds) > 0.9
-@test typeof(preds) <: Vector{Float64}
+        rng=StableRNG(1),
+    )
+    preds = apply_forest(model, features)
+    @test R2(labels, preds) > 0.9
+    @test typeof(preds) <: Vector{Float64}
 
-preds_MT = apply_forest(model, features, use_multithreading=true)
-@test R2(labels, preds_MT) > 0.9
-@test typeof(preds_MT) <: Vector{Float64}
-@test sum(abs.(preds .- preds_MT)) < 1.0e-8
+    preds_MT = apply_forest(model, features; use_multithreading=true)
+    @test R2(labels, preds_MT) > 0.9
+    @test typeof(preds_MT) <: Vector{Float64}
+    @test sum(abs.(preds .- preds_MT)) < 1.0e-8
 
-println("\n##### nfoldCV Regression Tree #####")
-n_folds             = Int32(3)
-pruning_purity      = 1.0
-max_depth           = Int32(-1)
-min_samples_leaf    = Int32(5)
-min_samples_split   = Int32(2)
-min_purity_increase = 0.0
-r2 = nfoldCV_tree(
-        labels, features,
+    println("\n##### nfoldCV Regression Tree #####")
+    n_folds = Int32(3)
+    pruning_purity = 1.0
+    max_depth = Int32(-1)
+    min_samples_leaf = Int32(5)
+    min_samples_split = Int32(2)
+    min_purity_increase = 0.0
+    r2 = nfoldCV_tree(
+        labels,
+        features,
         n_folds,
         pruning_purity,
         max_depth,
         min_samples_leaf,
         min_samples_split,
         min_purity_increase;
-        rng=StableRNG(1))
-@test mean(r2) > 0.6
+        rng=StableRNG(1),
+    )
+    @test mean(r2) > 0.6
 
-println("\n##### nfoldCV Regression Forest #####")
-n_trees             = Int32(10)
-n_subfeatures       = Int32(2)
-n_folds             = Int32(3)
-max_depth           = Int32(-1)
-min_samples_leaf    = Int32(5)
-min_samples_split   = Int32(2)
-min_purity_increase = 0.0
-r2 = nfoldCV_forest(
-        labels, features,
+    println("\n##### nfoldCV Regression Forest #####")
+    n_trees = Int32(10)
+    n_subfeatures = Int32(2)
+    n_folds = Int32(3)
+    max_depth = Int32(-1)
+    min_samples_leaf = Int32(5)
+    min_samples_split = Int32(2)
+    min_purity_increase = 0.0
+    r2 = nfoldCV_forest(
+        labels,
+        features,
         n_folds,
         n_subfeatures,
         n_trees,
@@ -88,31 +94,31 @@ r2 = nfoldCV_forest(
         min_samples_leaf,
         min_samples_split,
         min_purity_increase;
-        rng=StableRNG(1))
-@test mean(r2) > 0.8
+        rng=StableRNG(1),
+    )
+    @test mean(r2) > 0.8
 
-# Test Float16 labels, and Float16 features
-features  = Float16.(features)
-labels = Float16.(labels)
+    # Test Float16 labels, and Float16 features
+    features = Float16.(features)
+    labels = Float16.(labels)
 
-model = build_stump(labels, features)
-preds = apply_tree(model, features)
-@test typeof(preds) == Vector{Float16}
+    model = build_stump(labels, features)
+    preds = apply_tree(model, features)
+    @test typeof(preds) == Vector{Float16}
 
-model = build_tree(labels, features)
-preds = apply_tree(model, features)
-@test typeof(preds) == Vector{Float16}
+    model = build_tree(labels, features)
+    preds = apply_tree(model, features)
+    @test typeof(preds) == Vector{Float16}
 
-model = build_forest(labels, features)
-preds = apply_forest(model, features)
-@test typeof(preds) == Vector{Float16}
+    model = build_forest(labels, features)
+    preds = apply_forest(model, features)
+    @test typeof(preds) == Vector{Float16}
 
-preds_MT = apply_forest(model, features, use_multithreading = true)
-@test typeof(preds_MT) == Vector{Float16}
-@test sum(abs.(preds .- preds_MT)) < 1.0e-8
+    preds_MT = apply_forest(model, features; use_multithreading=true)
+    @test typeof(preds_MT) == Vector{Float16}
+    @test sum(abs.(preds .- preds_MT)) < 1.0e-8
 
-model = build_tree(labels, features)
-preds = apply_tree(model, features)
-@test typeof(preds) == Vector{Float16}
-
+    model = build_tree(labels, features)
+    preds = apply_tree(model, features)
+    @test typeof(preds) == Vector{Float16}
 end # @testset

--- a/test/regression/random.jl
+++ b/test/regression/random.jl
@@ -1,38 +1,58 @@
 @testset "scikitlearn.jl" begin
+    n, m = 10^3, 5
+    features = rand(StableRNG(1), n, m)
+    weights = rand(StableRNG(1), -1:1, m)
+    labels = features * weights
 
-n, m = 10^3, 5;
-features = rand(StableRNG(1), n, m);
-weights = rand(StableRNG(1), -1:1, m);
-labels = features * weights;
-
-model = fit!(DecisionTreeRegressor(; rng=StableRNG(1), min_samples_split=5), features, labels)
-@test R2(labels, predict(model, features)) > 0.8
-@test impurity_importance(model) == impurity_importance(model.root)
-@test isapprox(permutation_importance(model, features, labels, rng=StableRNG(1)).mean, permutation_importance(model.root, labels, features, (model, y, X) -> R2(y, apply_tree(model, X)), rng=StableRNG(1)).mean)
-
-let
-    regressor = RandomForestRegressor(; rng=StableRNG(1), n_trees=10, min_samples_leaf=5, n_subfeatures=2)
-    model = fit!(regressor, features, labels)
+    model = fit!(
+        DecisionTreeRegressor(; rng=StableRNG(1), min_samples_split=5), features, labels
+    )
     @test R2(labels, predict(model, features)) > 0.8
-    @test impurity_importance(model) == impurity_importance(model.ensemble)
-    @test split_importance(model) == split_importance(model.ensemble)
-    @test isapprox(permutation_importance(model, features, labels, rng=StableRNG(1)).mean, permutation_importance(model.ensemble, labels, features, (model, y, X) -> R2(y, apply_forest(model, X)), rng=StableRNG(1)).mean)
-end
+    @test impurity_importance(model) == impurity_importance(model.root)
+    @test isapprox(
+        permutation_importance(model, features, labels; rng=StableRNG(1)).mean,
+        permutation_importance(
+            model.root,
+            labels,
+            features,
+            (model, y, X) -> R2(y, apply_tree(model, X));
+            rng=StableRNG(1),
+        ).mean,
+    )
 
-Random.seed!(2)
-N = 3000
-X = randn(StableRNG(1), N, 10)
-y = randn(StableRNG(1), N)
-max_depth = 5
-model = fit!(DecisionTreeRegressor(; rng=StableRNG(1), max_depth=max_depth), X, y)
-@test depth(model) == max_depth
+    let
+        regressor = RandomForestRegressor(;
+            rng=StableRNG(1), n_trees=10, min_samples_leaf=5, n_subfeatures=2
+        )
+        model = fit!(regressor, features, labels)
+        @test R2(labels, predict(model, features)) > 0.8
+        @test impurity_importance(model) == impurity_importance(model.ensemble)
+        @test split_importance(model) == split_importance(model.ensemble)
+        @test isapprox(
+            permutation_importance(model, features, labels; rng=StableRNG(1)).mean,
+            permutation_importance(
+                model.ensemble,
+                labels,
+                features,
+                (model, y, X) -> R2(y, apply_forest(model, X));
+                rng=StableRNG(1),
+            ).mean,
+        )
+    end
 
-## Test that the RNG arguments work as expected
-X = randn(StableRNG(1), 100, 10)
-y = randn(StableRNG(1), 100)
-@test fit_predict!(RandomForestRegressor(; rng=10), X, y) ==
-    fit_predict!(RandomForestRegressor(; rng=10), X, y)
-@test fit_predict!(RandomForestRegressor(; rng=10), X, y) !=
-    fit_predict!(RandomForestRegressor(; rng=22), X, y)
+    Random.seed!(2)
+    N = 3000
+    X = randn(StableRNG(1), N, 10)
+    y = randn(StableRNG(1), N)
+    max_depth = 5
+    model = fit!(DecisionTreeRegressor(; rng=StableRNG(1), max_depth), X, y)
+    @test depth(model) == max_depth
 
+    ## Test that the RNG arguments work as expected
+    X = randn(StableRNG(1), 100, 10)
+    y = randn(StableRNG(1), 100)
+    @test fit_predict!(RandomForestRegressor(; rng=10), X, y) ==
+        fit_predict!(RandomForestRegressor(; rng=10), X, y)
+    @test fit_predict!(RandomForestRegressor(; rng=10), X, y) !=
+        fit_predict!(RandomForestRegressor(; rng=22), X, y)
 end # @testset

--- a/test/regression/scikitlearn.jl
+++ b/test/regression/scikitlearn.jl
@@ -1,39 +1,42 @@
 @testset "scikitlearn.jl" begin
+    n, m = 10^3, 5
+    features = rand(StableRNG(1), n, m)
+    weights = rand(StableRNG(1), -1:1, m)
+    labels = features * weights
 
-n, m = 10^3, 5;
-features = rand(StableRNG(1), n, m);
-weights = rand(StableRNG(1), -1:1, m);
-labels = features * weights;
+    let
+        regressor = DecisionTreeRegressor(;
+            rng=StableRNG(1), min_samples_leaf=5, pruning_purity_threshold=0.1
+        )
+        model = fit!(regressor, features, labels)
+        @test R2(labels, predict(model, features)) > 0.8
+    end
 
-let
-    regressor = DecisionTreeRegressor(; rng=StableRNG(1), min_samples_leaf=5, pruning_purity_threshold=0.1)
-    model = fit!(regressor, features, labels)
+    model = fit!(
+        DecisionTreeRegressor(; rng=StableRNG(1), min_samples_split=5), features, labels
+    )
     @test R2(labels, predict(model, features)) > 0.8
-end
 
-model = fit!(DecisionTreeRegressor(; rng=StableRNG(1), min_samples_split=5), features, labels)
-@test R2(labels, predict(model, features)) > 0.8
+    let
+        regressor = RandomForestRegressor(;
+            rng=StableRNG(1), n_trees=10, min_samples_leaf=5, n_subfeatures=2
+        )
+        model = fit!(regressor, features, labels)
+        @test R2(labels, predict(model, features)) > 0.8
+    end
 
-let
-    regressor = RandomForestRegressor(; rng=StableRNG(1), n_trees=10, min_samples_leaf=5, n_subfeatures=2)
-    model = fit!(regressor, features, labels)
-    @test R2(labels, predict(model, features)) > 0.8
-end
+    N = 3000
+    X = randn(StableRNG(1), N, 10)
+    y = randn(StableRNG(1), N)
+    max_depth = 5
+    model = fit!(DecisionTreeRegressor(; rng=StableRNG(1), max_depth), X, y)
+    @test depth(model) == max_depth
 
-N = 3000
-X = randn(StableRNG(1), N, 10)
-y = randn(StableRNG(1), N)
-max_depth = 5
-model = fit!(DecisionTreeRegressor(; rng=StableRNG(1), max_depth=max_depth), X, y)
-@test depth(model) == max_depth
-
-
-## Test that the RNG arguments work as expected
-X = randn(StableRNG(1), 100, 10)
-y = randn(StableRNG(1), 100)
-@test fit_predict!(RandomForestRegressor(; rng=10), X, y) ==
-    fit_predict!(RandomForestRegressor(; rng=10), X, y)
-@test fit_predict!(RandomForestRegressor(; rng=10), X, y) !=
-    fit_predict!(RandomForestRegressor(; rng=22), X, y)
-
+    ## Test that the RNG arguments work as expected
+    X = randn(StableRNG(1), 100, 10)
+    y = randn(StableRNG(1), 100)
+    @test fit_predict!(RandomForestRegressor(; rng=10), X, y) ==
+        fit_predict!(RandomForestRegressor(; rng=10), X, y)
+    @test fit_predict!(RandomForestRegressor(; rng=10), X, y) !=
+        fit_predict!(RandomForestRegressor(; rng=22), X, y)
 end # @testset

--- a/test/runbenchmarks.jl
+++ b/test/runbenchmarks.jl
@@ -8,7 +8,6 @@ include("benchmark/utils.jl")
 
 Random.seed!(1)
 
-
 # Classification Benchmarks
 classification_tree = benchmark_classification(build_tree, apply_tree)
 println("\n\n############### CLASSIFICATION: BUILD TREE ###############")
@@ -27,8 +26,6 @@ println("\n\n############### CLASSIFICATION: BUILD ADABOOST ###############")
 print_details(classification_adaboost["BUILD"])
 println("\n\n############### CLASSIFICATION: APPLY ADABOOST ###############")
 print_details(classification_adaboost["APPLY"])
-
-
 
 # Regression Benchmarks
 regression_tree = benchmark_regression(build_tree, apply_tree)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-import AbstractTrees
+using AbstractTrees: AbstractTrees
 
 using DecisionTree
 using DelimitedFiles
@@ -21,7 +21,7 @@ function run_tests(list)
     for test in list
         println("TEST: $test \n")
         include(test)
-        println("=" ^ 50)
+        println("="^50)
     end
 end
 
@@ -36,19 +36,19 @@ classification = [
     "classification/adding_trees.jl",
 ]
 
-regression =     [
+regression = [
     "regression/random.jl",
     "regression/low_precision.jl",
     "regression/digits.jl",
-    "regression/scikitlearn.jl"
+    "regression/scikitlearn.jl",
 ]
 
-miscellaneous =  [
+miscellaneous = [
     "miscellaneous/convert.jl",
     "miscellaneous/abstract_trees_test.jl",
     "miscellaneous/feature_importance_test.jl",
     "miscellaneous/ensemble_methods.jl",
-#    "miscellaneous/parallel.jl"
+    #    "miscellaneous/parallel.jl"
 
 ]
 


### PR DESCRIPTION
The formatting of `DecisionTree.jl` is sometimes inconsistent and using styles which are generally advised against such as aligning items vertically. This PR applies JuliaFormatter to the repository to get a coherent style. I've also tried to replace calls such as `f(; x = x)` by `f(; x)`. This is possible since Julia 1.5 ([NEWS.md](https://github.com/JuliaLang/julia/blob/v1.5.0/NEWS.md)) and this repository has a lower bound on Julia 1.6.

The command that I used to format the repository is:
```julia
julia> using JuliaFormatter

julia> format(".", BlueStyle(); always_use_return=false, import_to_using=false)

```
I've chosen the blue style because it's a pretty well-known and well thought out style, see [the BlueStyle repo](https://github.com/invenia/BlueStyle) for details.

We could also add a `.JuliaFormatter.toml` file to the root of the repository containing:

```toml
style = "blue"
always_use_return = false
import_to_using = false
```

To use the newer keyword arguments syntax, that is replace `f(; x = x)` by `f(; x)`, I've used `comby`:

```
$ comby -matcher .jl '(:[a]; :[b], :[c]=:[c])' '(:[a]; :[b], :[c])'
```
and some variations of this command.

I've also considered adding a CI workflow to check whether PRs satisfy the code style. However, this would be an extra burden to contributors so I think that an occasional run of the JuliaFormatter should be enough. 